### PR TITLE
Add Brightness control

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ shrinkwraprs = "0.3.0"
 cascade = "1.0.1"
 pulse = { version = "2.26.0", package = "libpulse-binding" }
 pulsectl-rs = "0.3.2"
+blight = "0.4.1"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ bindsym XF86MonBrightnessUp exec swayosd --brightness raise
 bindsym XF86MonBrightnessDown exec swayosd --brightness lower
 ```
 
+## Brightness Control
+Some devices may not have permission to write `/sys/class/backlight/*/brightness`.
+Workaround will be adding a rule inside `udev`:
+
+`/etc/udev/rules.d/99-swayosd.rules`
+
+```
+ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chgrp video /sys/class/backlight/%k/brightness"
+ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chmod g+w /sys/class/backlight/%k/brightness"
+```
+
 ## Install
 
 Available on the AUR thanks to @jgmdev!

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is my first time coding in Rust so fixes and improvements are appreciated :
 - Input and output volume change indicator
 - Input and output mute change indicator
 - Capslock change (Note: doesn't change the caps lock state)
+- Brightness change indicator
 
 ## Usage:
 
@@ -30,6 +31,11 @@ bindsym --release Caps_Lock exec swayosd --caps-lock
 
 # Capslock but specific LED name (/sys/class/leds/)
 bindsym --release Caps_Lock exec swayosd --caps-lock-led input19::capslock
+
+# Brightness raise
+bindsym XF86MonBrightnessUp exec swayosd --brightness raise
+# Brightness lower
+bindsym XF86MonBrightnessDown exec swayosd --brightness lower
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -40,14 +40,22 @@ bindsym XF86MonBrightnessDown exec swayosd --brightness lower
 
 ## Brightness Control
 Some devices may not have permission to write `/sys/class/backlight/*/brightness`.
+
 Workaround will be adding a rule inside `udev`:
 
+### Add `udev` rules
 `/etc/udev/rules.d/99-swayosd.rules`
 
 ```
 ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chgrp video /sys/class/backlight/%k/brightness"
 ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chmod g+w /sys/class/backlight/%k/brightness"
 ```
+
+### Add user to `video` group
+
+- Copy `sudo usermod -a -G video $LOGNAME` into a terminal
+- Logout and log back in
+- Fire up a terminal and type `groups` again, `video` should be listed alongside other groups.
 
 ## Install
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -25,6 +25,8 @@ pub enum OsdTypes {
 	SourceVolumeRaise = 5,
 	SourceVolumeLower = 6,
 	SourceVolumeMuteToggle = 7,
+	BrightnessRaise = 8,
+	BrightnessLower = 9,
 }
 impl OsdTypes {
 	pub fn as_str(&self) -> &'static str {
@@ -37,6 +39,8 @@ impl OsdTypes {
 			OsdTypes::SourceVolumeRaise => "SOURCE-VOLUME-RAISE",
 			OsdTypes::SourceVolumeLower => "SOURCE-VOLUME-LOWER",
 			OsdTypes::SourceVolumeMuteToggle => "SOURCE-VOLUME-MUTE-TOGGLE",
+			OsdTypes::BrightnessRaise => "BRIGHTNESS-RAISE",
+			OsdTypes::BrightnessLower => "BRIGHTNESS-LOWER",
 		}
 	}
 
@@ -50,6 +54,8 @@ impl OsdTypes {
 				"SOURCE-VOLUME-RAISE" => (OsdTypes::SourceVolumeRaise, value),
 				"SOURCE-VOLUME-LOWER" => (OsdTypes::SourceVolumeLower, value),
 				"SOURCE-VOLUME-MUTE-TOGGLE" => (OsdTypes::SourceVolumeMuteToggle, value),
+				"BRIGHTNESS-RAISE" => (OsdTypes::BrightnessRaise, value),
+				"BRIGHTNESS-LOWER" => (OsdTypes::BrightnessLower, value),
 				_ => (OsdTypes::None, None),
 			},
 			None => (OsdTypes::None, None),
@@ -107,6 +113,16 @@ impl SwayOSDApplication {
 			Some("raise|lower|mute-toggle"),
 		);
 
+		// Sink brightness cmdline arg
+		app.add_main_option(
+			"brightness",
+			glib::Char::from(0),
+			OptionFlags::NONE,
+			OptionArg::String,
+			"Shows brightness osd and raises or loweres all available sources of brightness device",
+			Some("raise|lower"),
+		);
+        
 		// Parse args
 		app.connect_handle_local_options(|app, args| -> i32 {
 			let variant = args.to_variant();
@@ -146,6 +162,14 @@ impl SwayOSDApplication {
 					"mute-toggle" => (OsdTypes::SourceVolumeMuteToggle, None),
 					e => {
 						eprintln!("Unknown input volume mode: \"{}\"!...", e);
+						return 1;
+					}
+				},
+				"brightness" => match child.value().str().unwrap_or("") {
+					"raise" => (OsdTypes::BrightnessRaise, None),
+					"lower" => (OsdTypes::BrightnessLower, None),
+					e => {
+						eprintln!("Unknown brightness mode: \"{}\"!...", e);
 						return 1;
 					}
 				},
@@ -277,6 +301,18 @@ impl SwayOSDApplication {
 						}
 						None => return,
 					}
+				}
+				(OsdTypes::BrightnessRaise, _) => {
+					change_brightness(BrightnessChangeType::Raise);
+                    for window in self.windows.borrow().to_owned() {
+                        window.changed_brightness();
+                    }
+				}
+				(OsdTypes::BrightnessLower, _) => {
+					change_brightness(BrightnessChangeType::Lower);
+                    for window in self.windows.borrow().to_owned() {
+                        window.changed_brightness();
+                    }
 				}
 				(OsdTypes::CapsLock, led) => {
 					let state = get_caps_lock_state(led);

--- a/src/application.rs
+++ b/src/application.rs
@@ -122,7 +122,7 @@ impl SwayOSDApplication {
 			"Shows brightness osd and raises or loweres all available sources of brightness device",
 			Some("raise|lower"),
 		);
-        
+
 		// Parse args
 		app.connect_handle_local_options(|app, args| -> i32 {
 			let variant = args.to_variant();
@@ -303,16 +303,18 @@ impl SwayOSDApplication {
 					}
 				}
 				(OsdTypes::BrightnessRaise, _) => {
-					change_brightness(BrightnessChangeType::Raise);
-                    for window in self.windows.borrow().to_owned() {
-                        window.changed_brightness();
-                    }
+					if let Ok(Some(device)) = change_brightness(BrightnessChangeType::Raise) {
+						for window in self.windows.borrow().to_owned() {
+							window.changed_brightness(&device);
+						}
+					}
 				}
 				(OsdTypes::BrightnessLower, _) => {
-					change_brightness(BrightnessChangeType::Lower);
-                    for window in self.windows.borrow().to_owned() {
-                        window.changed_brightness();
-                    }
+					if let Ok(Some(device)) = change_brightness(BrightnessChangeType::Lower) {
+						for window in self.windows.borrow().to_owned() {
+							window.changed_brightness(&device);
+						}
+					}
 				}
 				(OsdTypes::CapsLock, led) => {
 					let state = get_caps_lock_state(led);

--- a/src/osd_window.rs
+++ b/src/osd_window.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use gtk::{cairo, gdk, glib, prelude::*};
 use pulsectl::controllers::types::DeviceInfo;
 
-use crate::utils::{brightness_to_f64, volume_to_f64, VolumeDeviceType};
+use crate::utils::{volume_to_f64, VolumeDeviceType};
 use blight::Device;
 
 const DISABLED_OPACITY: f64 = 0.5;
@@ -160,23 +160,8 @@ impl SwayosdWindow {
 		self.clear_osd();
 
 		let bl = Device::new(None).unwrap();
-        let brightness = brightness_to_f64(&bl);
-        // in some theme they have this notification display.
-        //let icon_prefix = "notification-display-brightness";
-        //let mut icon_name = String::new();
+        let brightness = bl.current() as f64;
 
-        //if brightness > 0.0 && brightness <= 82.5
-        //{
-        //    icon_name = format!("{}-low", icon_prefix);
-        //} 
-        //else if brightness > 82.5 && brightness <= 165.0 {
-        //    icon_name = format!("{}-medium", icon_prefix);
-        //}
-        //else if brightness > 165.0 {
-        //    icon_name = format!("{}-medium", icon_prefix);
-        //}
-        //
-        
         // Using the icon from Adwaita for now?
         let icon_name = "display-brightness-symbolic";
 			

--- a/src/osd_window.rs
+++ b/src/osd_window.rs
@@ -6,7 +6,8 @@ use std::time::Duration;
 use gtk::{cairo, gdk, glib, prelude::*};
 use pulsectl::controllers::types::DeviceInfo;
 
-use crate::utils::{volume_to_f64, VolumeDeviceType};
+use crate::utils::{brightness_to_f64, volume_to_f64, VolumeDeviceType};
+use blight::Device;
 
 const DISABLED_OPACITY: f64 = 0.5;
 const ICON_SIZE: i32 = 32;
@@ -150,6 +151,27 @@ impl SwayosdWindow {
 		}
 
 		self.container.add(&icon);
+		self.container.add(&progress.bar);
+
+		self.run_timeout();
+	}
+
+	pub fn changed_brightness(&self) {
+		self.clear_osd();
+
+		let bl = Device::new(None).unwrap();
+        let brightness = brightness_to_f64(&bl);
+
+		// let icon = self.build_icon_widget(icon_name);
+		let progress = self.build_progress_widget(brightness);
+
+		//if device.mute {
+		//	progress.set_opacity(DISABLED_OPACITY);
+		//} else {
+		//	progress.set_opacity(1.0);
+		//}
+
+		// self.container.add(&icon);
 		self.container.add(&progress.bar);
 
 		self.run_timeout();

--- a/src/osd_window.rs
+++ b/src/osd_window.rs
@@ -161,17 +161,29 @@ impl SwayosdWindow {
 
 		let bl = Device::new(None).unwrap();
         let brightness = brightness_to_f64(&bl);
+        // in some theme they have this notification display.
+        //let icon_prefix = "notification-display-brightness";
+        //let mut icon_name = String::new();
 
-		// let icon = self.build_icon_widget(icon_name);
-		let progress = self.build_progress_widget(brightness);
+        //if brightness > 0.0 && brightness <= 82.5
+        //{
+        //    icon_name = format!("{}-low", icon_prefix);
+        //} 
+        //else if brightness > 82.5 && brightness <= 165.0 {
+        //    icon_name = format!("{}-medium", icon_prefix);
+        //}
+        //else if brightness > 165.0 {
+        //    icon_name = format!("{}-medium", icon_prefix);
+        //}
+        //
+        
+        // Using the icon from Adwaita for now?
+        let icon_name = "display-brightness-symbolic";
+			
+		let icon = self.build_icon_widget(&icon_name);
+		let progress = self.build_progress_widget(brightness / 255.0);
 
-		//if device.mute {
-		//	progress.set_opacity(DISABLED_OPACITY);
-		//} else {
-		//	progress.set_opacity(1.0);
-		//}
-
-		// self.container.add(&icon);
+		self.container.add(&icon);
 		self.container.add(&progress.bar);
 
 		self.run_timeout();

--- a/src/osd_window.rs
+++ b/src/osd_window.rs
@@ -156,17 +156,16 @@ impl SwayosdWindow {
 		self.run_timeout();
 	}
 
-	pub fn changed_brightness(&self) {
+	pub fn changed_brightness(&self, device: &Device) {
 		self.clear_osd();
 
-		let bl = Device::new(None).unwrap();
-        let brightness = bl.current() as f64;
-
-        // Using the icon from Adwaita for now?
-        let icon_name = "display-brightness-symbolic";
-			
+		// Using the icon from Adwaita for now?
+		let icon_name = "display-brightness-symbolic";
 		let icon = self.build_icon_widget(&icon_name);
-		let progress = self.build_progress_widget(brightness / 255.0);
+
+		let brightness = device.current() as f64;
+		let max = device.max() as f64;
+		let progress = self.build_progress_widget(brightness / max);
 
 		self.container.add(&icon);
 		self.container.add(&progress.bar);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use std::{
 
 use pulse::volume::Volume;
 use pulsectl::controllers::{types::DeviceInfo, DeviceControl, SinkController, SourceController};
-use blight:: { change_bl, Change, Device, Direction };
+use blight:: { change_bl, Change, Direction };
 
 pub fn get_caps_lock_state(led: Option<String>) -> bool {
 	const BASE_PATH: &str = "/sys/class/leds";
@@ -181,11 +181,6 @@ pub fn change_brightness(change_type: BrightnessChangeType) {
 		}
 	}
 }
-
-pub fn brightness_to_f64(dev: &Device) -> f64 {
-    dev.current() as f64
-}
-
 
 pub fn volume_to_f64(volume: &Volume) -> f64 {
 	let tmp_vol = f64::from(volume.0 - Volume::MUTED.0);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -183,8 +183,7 @@ pub fn change_brightness(change_type: BrightnessChangeType) {
 }
 
 pub fn brightness_to_f64(dev: &Device) -> f64 {
-	let tmp_bright = dev.current() as f64;
-	tmp_bright / 255.0
+    dev.current() as f64
 }
 
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,7 @@ use std::{
 
 use pulse::volume::Volume;
 use pulsectl::controllers::{types::DeviceInfo, DeviceControl, SinkController, SourceController};
+use blight:: { change_bl, Change, Device, Direction };
 
 pub fn get_caps_lock_state(led: Option<String>) -> bool {
 	const BASE_PATH: &str = "/sys/class/leds";
@@ -63,6 +64,11 @@ pub enum VolumeChangeType {
 pub enum VolumeDeviceType {
 	Sink,
 	Source,
+}
+
+pub enum BrightnessChangeType {
+	Raise,
+	Lower,
 }
 
 pub fn change_sink_volume(change_type: VolumeChangeType) -> Option<DeviceInfo> {
@@ -156,6 +162,31 @@ pub fn change_source_volume(change_type: VolumeChangeType) -> Option<DeviceInfo>
 		}
 	}
 }
+
+pub fn change_brightness(change_type: BrightnessChangeType) {
+
+	const BRIGHTNESS_CHANGE_DELTA: u16 = 5;
+	match change_type {
+		BrightnessChangeType::Raise => {
+            match change_bl(BRIGHTNESS_CHANGE_DELTA, Change::Regular, Direction::Inc, None) {
+                Err(e) => eprintln!("Brightness Error: {}", e),
+                _ => ()
+            }
+		}
+		BrightnessChangeType::Lower => {
+            match change_bl(BRIGHTNESS_CHANGE_DELTA, Change::Regular, Direction::Dec, None) {
+                Err(e) => eprintln!("Brightness Error: {}", e),
+                _ => ()
+            }
+		}
+	}
+}
+
+pub fn brightness_to_f64(dev: &Device) -> f64 {
+	let tmp_bright = dev.current() as f64;
+	tmp_bright / 255.0
+}
+
 
 pub fn volume_to_f64(volume: &Volume) -> f64 {
 	let tmp_vol = f64::from(volume.0 - Volume::MUTED.0);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -167,17 +167,17 @@ pub fn change_brightness(change_type: BrightnessChangeType) {
 
 	const BRIGHTNESS_CHANGE_DELTA: u16 = 5;
 	match change_type {
-		BrightnessChangeType::Raise => {
+	BrightnessChangeType::Raise => {
             match change_bl(BRIGHTNESS_CHANGE_DELTA, Change::Regular, Direction::Inc, None) {
                 Err(e) => eprintln!("Brightness Error: {}", e),
                 _ => ()
             }
 		}
-		BrightnessChangeType::Lower => {
+	BrightnessChangeType::Lower => {
             match change_bl(BRIGHTNESS_CHANGE_DELTA, Change::Regular, Direction::Dec, None) {
                 Err(e) => eprintln!("Brightness Error: {}", e),
                 _ => ()
-            }
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is my first time working with rust, so if anything can be improved, please tell me.

I add a blight package to let users control the backlight.
It's tested on my laptop with multiple external screens running and worked flawlessly.
Sadly, I don't have an external monitor that can be adjusted the backlight from the drivers.
The brightness icon heavily depends on the theme files. For now, I'm using Adwaita's `display-brightness-symbolic` icon.
if desire to have different icon between different level of the brightness,
perhaps have to do something like this
```
        // in some themes they have this notification display.
        let icon_prefix = "notification-display-brightness";
        let mut icon_name = String::new();

        if brightness > 0.0 && brightness <= 82.5
        {
            icon_name = format!("{}-low", icon_prefix);
        } 
        else if brightness > 82.5 && brightness <= 165.0 {
            icon_name = format!("{}-medium", icon_prefix);
        }
        else if brightness > 165.0 {
            icon_name = format!("{}-medium", icon_prefix);
        }
```

## What changed
### General
- Update README.md file with brightness instruction
- Add parameters of brightness control
- Add function to control brightness using `blight` package.

### Package
- Added `blight = "0.4.1"`

### Issue related
#1

