### PR TITLE
Add the ability to specify the audio device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,9 +484,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libpulse-binding"
@@ -654,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "6.0.5"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fe581ad25d11420b873cf9aedaca0419c2b411487b134d4d21065f3d092055"
+checksum = "e5fa6fb9ee296c0dc2df41a656ca7948546d061958115ddb0bcaae43ad0d17d2"
 dependencies = [
  "cfg-expr",
  "heck",

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ bindsym XF86MonBrightnessUp exec swayosd --brightness raise
 bindsym XF86MonBrightnessDown exec swayosd --brightness lower --device alsa_output.pci-0000_11_00.4.analog-stereo.monitor
 ```
 
-Notes on using `--device`:
+#### Notes on using `--device`:
  - It is for audio devices only.
  - If it is omitted the default audio device is used.
  - It only changes the target device for the currrent/next action that changes the volume.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,18 @@ bindsym --release Caps_Lock exec swayosd --caps-lock
 # Capslock but specific LED name (/sys/class/leds/)
 bindsym --release Caps_Lock exec swayosd --caps-lock-led input19::capslock
 
-# Brightness raise
+# Brightness raise optionally with --device
 bindsym XF86MonBrightnessUp exec swayosd --brightness raise
-# Brightness lower
-bindsym XF86MonBrightnessDown exec swayosd --brightness lower
+# Brightness lower optionally with --device
+bindsym XF86MonBrightnessDown exec swayosd --brightness lower --device alsa_output.pci-0000_11_00.4.analog-stereo.monitor
 ```
+
+Notes on using `--device`:
+ - It is for audio devices only.
+ - If it is omitted the default audio device is used.
+ - It only changes the target device for the currrent/next action that changes the volume.
+ - `--max-volume` is a global limit for all devices so `--device` has no effect on it.
+ - You can list your input audio devices using `pactl list short sources`, for outputs replace `sources' with `sinks`.
 
 ## Brightness Control
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ exec swayosd --max-volume 120
 ```
 
 ```zsh
-# Sink volume raise
+# Sink volume raise optionally with --device
 bindsym XF86AudioRaiseVolume exec swayosd --output-volume raise
-# Sink volume lower
-bindsym XF86AudioLowerVolume exec  swayosd --output-volume lower
+# Sink volume lower optionally with --device
+bindsym XF86AudioLowerVolume exec  swayosd --output-volume lower --device alsa_output.pci-0000_11_00.4.analog-stereo.monitor
 # Sink volume toggle mute
 bindsym XF86AudioMute exec swayosd --output-volume mute-toggle
 # Source volume toggle mute
@@ -39,10 +39,10 @@ bindsym --release Caps_Lock exec swayosd --caps-lock
 # Capslock but specific LED name (/sys/class/leds/)
 bindsym --release Caps_Lock exec swayosd --caps-lock-led input19::capslock
 
-# Brightness raise optionally with --device
+# Brightness raise
 bindsym XF86MonBrightnessUp exec swayosd --brightness raise
-# Brightness lower optionally with --device
-bindsym XF86MonBrightnessDown exec swayosd --brightness lower --device alsa_output.pci-0000_11_00.4.analog-stereo.monitor
+# Brightness lower
+bindsym XF86MonBrightnessDown exec swayosd --brightness lower
 ```
 
 #### Notes on using `--device`:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Notes on using `--device`:
  - If it is omitted the default audio device is used.
  - It only changes the target device for the currrent/next action that changes the volume.
  - `--max-volume` is a global limit for all devices so `--device` has no effect on it.
- - You can list your input audio devices using `pactl list short sources`, for outputs replace `sources' with `sinks`.
+ - You can list your input audio devices using `pactl list short sources`, for outputs replace `sources` with `sinks`.
 
 ## Brightness Control
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -16,7 +16,7 @@ use gtk::gio::SimpleAction;
 const ACTION_NAME: &str = "action";
 const ACTION_FORMAT: &str = "(ss)";
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub enum ArgTypes {
 	None = -1,
 	// should always be first to set a global variable before executing volume-raise/lower
@@ -236,11 +236,7 @@ impl SwayOSDApplication {
 					}
 				};
 				if option != ArgTypes::None {
-					let variant = Variant::tuple_from_iter([
-						option.as_str().to_variant(),
-						value.unwrap_or(String::new()).to_variant(),
-					]);
-					actions.push((ACTION_NAME, Some(variant)));
+					actions.push((option, value));
 				}
 			}
 
@@ -257,8 +253,11 @@ impl SwayOSDApplication {
 
 			// execute the sorted actions
 			for action in actions {
-				println!("{:?}", action.1);
-				app.activate_action(action.0, Some(&action.1.unwrap()));
+				let variant = Variant::tuple_from_iter([
+					action.0.as_str().to_variant(),
+					action.1.unwrap_or(String::new()).to_variant(),
+				]);
+				app.activate_action(ACTION_NAME, Some(&variant));
 			}
 			0
 		});

--- a/src/application.rs
+++ b/src/application.rs
@@ -106,7 +106,7 @@ impl SwayOSDApplication {
 			OptionFlags::NONE,
 			OptionArg::String,
 			"Shows volume osd and raises, loweres or mutes default sink volume",
-			Some("raise|lower|mute-toggle|(±)number"),
+			Some("raise|lower|mute-toggle|(±)number [device]"),
 		);
 		// Sink volume cmdline arg
 		app.add_main_option(
@@ -115,7 +115,7 @@ impl SwayOSDApplication {
 			OptionFlags::NONE,
 			OptionArg::String,
 			"Shows volume osd and raises, loweres or mutes default source volume",
-			Some("raise|lower|mute-toggle|(±)number"),
+			Some("raise|lower|mute-toggle|(±)number [device]"),
 		);
 
 		// Sink brightness cmdline arg
@@ -163,44 +163,18 @@ impl SwayOSDApplication {
 					},
 					"output-volume" => {
 						let value = child.value().str().unwrap_or("");
-						match (value, value.parse::<i8>()) {
-							// Parse custom step values
-							(_, Ok(num)) => (
-								if num.is_positive() {
-									ArgTypes::SinkVolumeRaise
-								} else {
-									ArgTypes::SinkVolumeLower
-								},
-								Some(num.abs().to_string()),
-							),
-							("raise", _) => (ArgTypes::SinkVolumeRaise, None),
-							("lower", _) => (ArgTypes::SinkVolumeLower, None),
-							("mute-toggle", _) => (ArgTypes::SinkVolumeMuteToggle, None),
-							(e, _) => {
-								eprintln!("Unknown output volume mode: \"{}\"!...", e);
-								return 1;
-							}
+						let parsed = volume_parser(0, value);
+						match parsed {
+							Ok(p) => (p.0, p.1),
+							Err(e) => return e,
 						}
 					}
 					"input-volume" => {
 						let value = child.value().str().unwrap_or("");
-						match (value, value.parse::<i8>()) {
-							// Parse custom step values
-							(_, Ok(num)) => (
-								if num.is_positive() {
-									ArgTypes::SourceVolumeRaise
-								} else {
-									ArgTypes::SourceVolumeLower
-								},
-								Some(num.abs().to_string()),
-							),
-							("raise", _) => (ArgTypes::SourceVolumeRaise, None),
-							("lower", _) => (ArgTypes::SourceVolumeLower, None),
-							("mute-toggle", _) => (ArgTypes::SourceVolumeMuteToggle, None),
-							(e, _) => {
-								eprintln!("Unknown input volume mode: \"{}\"!...", e);
-								return 1;
-							}
+						let parsed = volume_parser(1, value);
+						match parsed {
+							Ok(p) => (p.0, p.1),
+							Err(e) => return e,
 						}
 					}
 					"brightness" => {

--- a/src/application.rs
+++ b/src/application.rs
@@ -254,9 +254,9 @@ impl SwayOSDApplication {
 			// execute the sorted actions
 			for action in actions {
 				let variant = Variant::tuple_from_iter([
-						action.0.as_str().to_variant(),
-						action.1.unwrap_or(String::new()).to_variant(),
-					]);
+					action.0.as_str().to_variant(),
+					action.1.unwrap_or(String::new()).to_variant(),
+				]);
 				app.activate_action(ACTION_NAME, Some(&variant));
 			}
 			0

--- a/src/application.rs
+++ b/src/application.rs
@@ -176,7 +176,7 @@ impl SwayOSDApplication {
 					},
 					"output-volume" => {
 						let value = child.value().str().unwrap_or("");
-						let parsed = volume_parser(0, value);
+						let parsed = volume_parser(false, value);
 						match parsed {
 							Ok(p) => p,
 							Err(e) => return e,
@@ -184,7 +184,7 @@ impl SwayOSDApplication {
 					}
 					"input-volume" => {
 						let value = child.value().str().unwrap_or("");
-						let parsed = volume_parser(1, value);
+						let parsed = volume_parser(true, value);
 						match parsed {
 							Ok(p) => p,
 							Err(e) => return e,

--- a/src/application.rs
+++ b/src/application.rs
@@ -178,7 +178,7 @@ impl SwayOSDApplication {
 						let value = child.value().str().unwrap_or("");
 						let parsed = volume_parser(0, value);
 						match parsed {
-							Ok(p) => (p.0, p.1),
+							Ok(p) => p,
 							Err(e) => return e,
 						}
 					}
@@ -186,7 +186,7 @@ impl SwayOSDApplication {
 						let value = child.value().str().unwrap_or("");
 						let parsed = volume_parser(1, value);
 						match parsed {
-							Ok(p) => (p.0, p.1),
+							Ok(p) => p,
 							Err(e) => return e,
 						}
 					}

--- a/src/application.rs
+++ b/src/application.rs
@@ -300,7 +300,7 @@ impl SwayOSDApplication {
 				(ArgTypes::SinkVolumeRaise, step) => {
 					let mut device_type = VolumeDeviceType::Sink(SinkController::create().unwrap());
 					if let Some(device) =
-						change_device_volume(&mut device_type, VolumeChangeType::Raise, step)
+						change_device_volume(&mut device_type, VolumeChangeType::Raise, step, None)
 					{
 						for window in self.windows.borrow().to_owned() {
 							window.changed_volume(&device, &device_type);
@@ -310,7 +310,7 @@ impl SwayOSDApplication {
 				(ArgTypes::SinkVolumeLower, step) => {
 					let mut device_type = VolumeDeviceType::Sink(SinkController::create().unwrap());
 					if let Some(device) =
-						change_device_volume(&mut device_type, VolumeChangeType::Lower, step)
+						change_device_volume(&mut device_type, VolumeChangeType::Lower, step, None)
 					{
 						for window in self.windows.borrow().to_owned() {
 							window.changed_volume(&device, &device_type);
@@ -319,9 +319,12 @@ impl SwayOSDApplication {
 				}
 				(ArgTypes::SinkVolumeMuteToggle, _) => {
 					let mut device_type = VolumeDeviceType::Sink(SinkController::create().unwrap());
-					if let Some(device) =
-						change_device_volume(&mut device_type, VolumeChangeType::MuteToggle, None)
-					{
+					if let Some(device) = change_device_volume(
+						&mut device_type,
+						VolumeChangeType::MuteToggle,
+						None,
+						None,
+					) {
 						for window in self.windows.borrow().to_owned() {
 							window.changed_volume(&device, &device_type);
 						}
@@ -331,7 +334,7 @@ impl SwayOSDApplication {
 					let mut device_type =
 						VolumeDeviceType::Source(SourceController::create().unwrap());
 					if let Some(device) =
-						change_device_volume(&mut device_type, VolumeChangeType::Raise, step)
+						change_device_volume(&mut device_type, VolumeChangeType::Raise, step, None)
 					{
 						for window in self.windows.borrow().to_owned() {
 							window.changed_volume(&device, &device_type);
@@ -342,7 +345,7 @@ impl SwayOSDApplication {
 					let mut device_type =
 						VolumeDeviceType::Source(SourceController::create().unwrap());
 					if let Some(device) =
-						change_device_volume(&mut device_type, VolumeChangeType::Lower, step)
+						change_device_volume(&mut device_type, VolumeChangeType::Lower, step, None)
 					{
 						for window in self.windows.borrow().to_owned() {
 							window.changed_volume(&device, &device_type);
@@ -352,9 +355,12 @@ impl SwayOSDApplication {
 				(ArgTypes::SourceVolumeMuteToggle, _) => {
 					let mut device_type =
 						VolumeDeviceType::Source(SourceController::create().unwrap());
-					if let Some(device) =
-						change_device_volume(&mut device_type, VolumeChangeType::MuteToggle, None)
-					{
+					if let Some(device) = change_device_volume(
+						&mut device_type,
+						VolumeChangeType::MuteToggle,
+						None,
+						None,
+					) {
 						for window in self.windows.borrow().to_owned() {
 							window.changed_volume(&device, &device_type);
 						}

--- a/src/application.rs
+++ b/src/application.rs
@@ -406,9 +406,7 @@ impl SwayOSDApplication {
 					}
 				}
 				(ArgTypes::MaxVolume, max) => set_max_volume(max),
-				(ArgTypes::DeviceName, name) => {
-					set_device_name(name.unwrap())
-			},
+				(ArgTypes::DeviceName, name) => set_device_name(name.unwrap()),
 				(ArgTypes::None, _) => {
 					eprintln!("Failed to parse variant: {}!...", variant.print(true))
 				}

--- a/src/application.rs
+++ b/src/application.rs
@@ -247,7 +247,7 @@ impl SwayOSDApplication {
 			// sort actions so that they always get executed in the correct order
 			for i in 0..actions.len() - 1 {
 				for j in i + 1..actions.len() {
-					if i < j && actions[i].0 > actions[j].0 {
+					if actions[i].0 > actions[j].0 {
 						let temp = actions[i].clone();
 						actions[i] = actions[j].clone();
 						actions[j] = temp;
@@ -411,7 +411,9 @@ impl SwayOSDApplication {
 					}
 				}
 				(ArgTypes::MaxVolume, max) => set_max_volume(max),
-				(ArgTypes::DeviceName, name) => {}
+				(ArgTypes::DeviceName, name) => {
+					println!("Device name was called: {:?}", name);
+				}
 				(ArgTypes::None, _) => {
 					eprintln!("Failed to parse variant: {}!...", variant.print(true))
 				}

--- a/src/application.rs
+++ b/src/application.rs
@@ -110,7 +110,7 @@ impl SwayOSDApplication {
 			OptionFlags::NONE,
 			OptionArg::String,
 			"Shows volume osd and raises, loweres or mutes default sink volume",
-			Some("raise|lower|mute-toggle|(±)number [device]"),
+			Some("raise|lower|mute-toggle|(±)number"),
 		);
 		// Sink volume cmdline arg
 		app.add_main_option(
@@ -119,7 +119,7 @@ impl SwayOSDApplication {
 			OptionFlags::NONE,
 			OptionArg::String,
 			"Shows volume osd and raises, loweres or mutes default source volume",
-			Some("raise|lower|mute-toggle|(±)number [device]"),
+			Some("raise|lower|mute-toggle|(±)number"),
 		);
 
 		// Sink brightness cmdline arg

--- a/src/application.rs
+++ b/src/application.rs
@@ -224,12 +224,10 @@ impl SwayOSDApplication {
 			// sort actions so that they always get executed in the correct order
 			for i in 0..actions.len() - 1 {
 				for j in i + 1..actions.len() {
-					if i < j {
-						if actions[i].0 > actions[j].0 {
-							let temp = actions[i].clone();
-							actions[i] = actions[j].clone();
-							actions[j] = temp;
-						}
+					if i < j && actions[i].0 > actions[j].0 {
+						let temp = actions[i].clone();
+						actions[i] = actions[j].clone();
+						actions[j] = temp;
 					}
 				}
 			}

--- a/src/application.rs
+++ b/src/application.rs
@@ -47,7 +47,7 @@ impl ArgTypes {
 			ArgTypes::SourceVolumeMuteToggle => "SOURCE-VOLUME-MUTE-TOGGLE",
 			ArgTypes::BrightnessRaise => "BRIGHTNESS-RAISE",
 			ArgTypes::BrightnessLower => "BRIGHTNESS-LOWER",
-			ArgTypes::DeviceName => "DEVICE-NAME"
+			ArgTypes::DeviceName => "DEVICE-NAME",
 		}
 	}
 
@@ -411,9 +411,7 @@ impl SwayOSDApplication {
 					}
 				}
 				(ArgTypes::MaxVolume, max) => set_max_volume(max),
-				(ArgTypes::DeviceName, name) => {
-					
-				}
+				(ArgTypes::DeviceName, name) => {}
 				(ArgTypes::None, _) => {
 					eprintln!("Failed to parse variant: {}!...", variant.print(true))
 				}

--- a/src/application.rs
+++ b/src/application.rs
@@ -18,9 +18,7 @@ const ACTION_FORMAT: &str = "(ss)";
 
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub enum ArgTypes {
-	None = -1,
-	// should always be first to set a global variable before executing volume-raise/lower
-	DeviceName = 0,
+	None = 0,
 	CapsLock = 1,
 	MaxVolume = 2,
 	SinkVolumeRaise = 3,
@@ -31,6 +29,8 @@ pub enum ArgTypes {
 	SourceVolumeMuteToggle = 8,
 	BrightnessRaise = 9,
 	BrightnessLower = 10,
+	// should always be first to set a global variable before executing related functions
+	DeviceName = isize::MIN,
 }
 
 impl ArgTypes {
@@ -254,9 +254,9 @@ impl SwayOSDApplication {
 			// execute the sorted actions
 			for action in actions {
 				let variant = Variant::tuple_from_iter([
-					action.0.as_str().to_variant(),
-					action.1.unwrap_or(String::new()).to_variant(),
-				]);
+						action.0.as_str().to_variant(),
+						action.1.unwrap_or(String::new()).to_variant(),
+					]);
 				app.activate_action(ACTION_NAME, Some(&variant));
 			}
 			0

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ lazy_static! {
 	static ref DEVICE_NAME: Mutex<String> = Mutex::new("default".to_string());
 }
 
-pub fn volume_parser(io: i8, value: &str) -> Result<(ArgTypes, Option<String>), i32> {
+pub fn volume_parser(is_sink: bool, value: &str) -> Result<(ArgTypes, Option<String>), i32> {
 	let mut v = match (value, value.parse::<i8>()) {
 		// Parse custom step values
 		(_, Ok(num)) => (
@@ -38,7 +38,7 @@ pub fn volume_parser(io: i8, value: &str) -> Result<(ArgTypes, Option<String>), 
 			return Err(1);
 		}
 	};
-	if io == 1 {
+	if is_sink {
 		if v.0 == ArgTypes::SinkVolumeRaise {
 			v.0 = ArgTypes::SourceVolumeRaise;
 		} else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -139,6 +139,7 @@ pub fn change_device_volume(
 					}
 				},
 			};
+			println!("{}", device_name);
 			match controller.get_device_by_name(&device_name) {
 				Ok(device) => (device, device_name.clone()),
 				Err(_) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -138,20 +138,19 @@ pub fn change_device_volume(
 	let (device, device_name): (DeviceInfo, String) = match device_type {
 		VolumeDeviceType::Sink(controller) => {
 			let server_info = controller.get_server_info();
-			let device_name;
 			let global_name = get_device_name();
-			if global_name == "default" {
-				device_name = match server_info {
+			let device_name: String = if global_name == "default" {
+				match server_info {
 					Ok(info) => info.default_sink_name.unwrap_or("".to_string()),
 					Err(e) => {
 						eprintln!("Error getting default_sink: {}", e);
 						return None;
 					}
-				};
+				}
 			} else {
-				device_name = global_name;
 				set_device_name("default".to_string());
-			}
+				global_name
+			};
 			match controller.get_device_by_name(&device_name) {
 				Ok(device) => (device, device_name.clone()),
 				Err(_) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -161,17 +161,23 @@ pub fn change_device_volume(
 		}
 		VolumeDeviceType::Source(controller) => {
 			let server_info = controller.get_server_info();
-			let device_name = &match server_info {
-				Ok(info) => info.default_sink_name.unwrap_or("".to_string()),
-				Err(e) => {
-					eprintln!("Pulse Error: {}", e);
-					return None;
+			let global_name = get_device_name();
+			let device_name: String = if global_name == "default" {
+				match server_info {
+					Ok(info) => info.default_source_name.unwrap_or("".to_string()),
+					Err(e) => {
+						eprintln!("Error getting default_source: {}", e);
+						return None;
+					}
 				}
+			} else {
+				set_device_name("default".to_string());
+				global_name
 			};
-			match controller.get_device_by_name(device_name) {
+			match controller.get_device_by_name(&device_name) {
 				Ok(device) => (device, device_name.clone()),
-				Err(e) => {
-					eprintln!("Pulse Error: {}", e);
+				Err(_) => {
+					eprintln!("No device with name: '{}' found!", device_name);
 					return None;
 				}
 			}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -64,7 +64,6 @@ pub fn get_device_name() -> String {
 }
 
 pub fn set_device_name(name: String) {
-	println!("setting global name to: {}", name);
 	let mut global_name = DEVICE_NAME.lock().unwrap();
 	*global_name = name;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -139,7 +139,6 @@ pub fn change_device_volume(
 					}
 				},
 			};
-			println!("{}", device_name);
 			match controller.get_device_by_name(&device_name) {
 				Ok(device) => (device, device_name.clone()),
 				Err(_) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -124,21 +124,25 @@ pub fn change_device_volume(
 	device_type: &mut VolumeDeviceType,
 	change_type: VolumeChangeType,
 	step: Option<String>,
+	name: Option<String>,
 ) -> Option<DeviceInfo> {
 	let (device, device_name): (DeviceInfo, String) = match device_type {
 		VolumeDeviceType::Sink(controller) => {
 			let server_info = controller.get_server_info();
-			let device_name = &match server_info {
-				Ok(info) => info.default_sink_name.unwrap_or("".to_string()),
-				Err(e) => {
-					eprintln!("Pulse Error: {}", e);
-					return None;
-				}
+			let device_name = match name {
+				Some(n) => n,
+				None => match server_info {
+					Ok(info) => info.default_sink_name.unwrap_or("".to_string()),
+					Err(e) => {
+						eprintln!("Error getting default_sink: {}", e);
+						return None;
+					}
+				},
 			};
-			match controller.get_device_by_name(device_name) {
+			match controller.get_device_by_name(&device_name) {
 				Ok(device) => (device, device_name.clone()),
-				Err(e) => {
-					eprintln!("Pulse Error: {}", e);
+				Err(_) => {
+					eprintln!("No device with that name found!");
 					return None;
 				}
 			}


### PR DESCRIPTION
Adds the `--device` argument to specify which audio device should be affected by a change in volume.

This would close the issue #11 and fixes a bug I noticed with my BubbleSort.
I also put the parsing for if the volume should increase or decrease in a separate function. I would like to say this is to be consistent with you merging `change_sink_volume` and `change_source_volume` but then I would be lying. I originally planned to have `change_device_volume` accept an additional input derived from an extra argument when using `--output-volume` or `--input-volume` so I moved it to an extra function in preparation for that. However it seems that GTK does not allow for an option with 2 arguments, or I am to stupid to figure it out. As a result of that I created a second global variable that stores which device should be affected.

This also comes with the benefit of these 2 approaches being the exact same.
1. `swayosd --output-volume 5 --device [NAME]`
2. `swayosd --device [NAME]` then afterwards `swayosd --output-volume 5`

I doubt anyone prefers option 2 but you never know.
If you have any further questions, that are not covered in the small "Notes on using `--device`:" section in the README, you know where to find me.