### PR TITLE
add parameter `--top-margin`

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -34,9 +34,9 @@ pub enum ArgTypes {
 	BrightnessLower = 10,
 	NumLock = 11,
 	ScrollLock = 12,
-	TopMargin = 13,
 	// should always be first to set a global variable before executing related functions
 	DeviceName = isize::MIN,
+	TopMargin = isize::MIN + 1
 }
 
 impl fmt::Display for ArgTypes {

--- a/src/osd_window.rs
+++ b/src/osd_window.rs
@@ -10,7 +10,7 @@ use gtk::{
 };
 use pulsectl::controllers::types::DeviceInfo;
 
-use crate::utils::{volume_to_f64, KeysLocks, VolumeDeviceType};
+use crate::utils::{volume_to_f64, KeysLocks, VolumeDeviceType, get_top_margin};
 use blight::Device;
 
 const DISABLED_OPACITY: f64 = 0.5;
@@ -109,7 +109,7 @@ impl SwayosdWindow {
 		// Set the window margin
 		window.connect_map(clone!(@strong monitor => move |win| {
 			let bottom = monitor.workarea().height() - win.height_request();
-			let margin = (bottom as f32 * 0.75).round() as i32;
+			let margin = (bottom as f32 * get_top_margin()).round() as i32;
 			gtk_layer_shell::set_margin(win, gtk_layer_shell::Edge::Top, margin);
 		}));
 

--- a/src/osd_window.rs
+++ b/src/osd_window.rs
@@ -40,6 +40,7 @@ impl SwayosdWindow {
 		gtk_layer_shell::set_monitor(&window, monitor);
 		gtk_layer_shell::set_namespace(&window, "swayosd");
 
+		gtk_layer_shell::set_exclusive_zone(&window, -1);
 		gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Overlay);
 		gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Top, true);
 
@@ -108,7 +109,7 @@ impl SwayosdWindow {
 
 		// Set the window margin
 		window.connect_map(clone!(@strong monitor => move |win| {
-			let bottom = monitor.workarea().height() - win.height_request();
+			let bottom = monitor.workarea().height() - win.allocated_height();
 			let margin = (bottom as f32 * get_top_margin()).round() as i32;
 			gtk_layer_shell::set_margin(win, gtk_layer_shell::Edge::Top, margin);
 		}));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,6 +17,7 @@ use crate::application::ArgTypes;
 lazy_static! {
 	static ref MAX_VOLUME: Mutex<u8> = Mutex::new(100_u8);
 	static ref DEVICE_NAME: Mutex<String> = Mutex::new("default".to_string());
+	static ref TOP_MARGIN: Mutex<f32> = Mutex::new(0.75_f32);
 }
 
 pub enum KeysLocks {
@@ -64,6 +65,17 @@ pub fn set_max_volume(volume: Option<String>) {
 	let setter: u8 = volume.unwrap().parse().unwrap();
 
 	let mut vol = MAX_VOLUME.lock().unwrap();
+	*vol = setter;
+}
+
+pub fn get_top_margin() -> f32 {
+	*TOP_MARGIN.lock().unwrap()
+}
+
+pub fn set_top_margin(volume: Option<String>) {
+	let setter: f32 = volume.unwrap().parse().unwrap();
+
+	let mut vol = TOP_MARGIN.lock().unwrap();
 	*vol = setter;
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,7 +17,7 @@ use crate::application::ArgTypes;
 lazy_static! {
 	static ref MAX_VOLUME: Mutex<u8> = Mutex::new(100_u8);
 	static ref DEVICE_NAME: Mutex<String> = Mutex::new("default".to_string());
-	static ref TOP_MARGIN: Mutex<f32> = Mutex::new(0.75_f32);
+	static ref TOP_MARGIN: Mutex<f32> = Mutex::new(0.85_f32);
 }
 
 pub enum KeysLocks {


### PR DESCRIPTION
This PR allows setting the top margin from the command line with the parameter `--top-margin` in a range from 0.0 to 1.0.

This should not break older installations because `--top-margin` is optional and defaults to the old value of `0.75`.