### PR TITLE
Change udev rules install_dir to libdir

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,5 +1,4 @@
 datadir = get_option('datadir')
-sysconfdir = get_option('sysconfdir')
 libdir = get_option('libdir')
 
 # LICENSE
@@ -10,7 +9,7 @@ install_data(
 # udev rules
 install_data(
   join_paths('udev', '99-swayosd.rules'),
-  install_dir: join_paths(sysconfdir, 'udev', 'rules.d')
+  install_dir: join_paths(libdir, 'udev', 'rules.d')
 )
 # Dbus conf
 install_data(


### PR DESCRIPTION
According to https://wiki.archlinux.org/title/Udev#About_udev_rules:
- The udev rules shipped with packages should be in `/usr/lib/udev/rules.d/`.
- `/etc/udev/rules.d` is for user edit.