### PR TITLE
Show volume overamplification

### DIFF
--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -144,11 +144,11 @@ fn main() -> Result<(), glib::Error> {
 		let variant = args.to_variant();
 		if variant.n_children() == 0 {
 			eprintln!("No args provided...");
-			return HandleLocalStatus::FAILIURE as i32;
+			return HandleLocalStatus::FAILURE as i32;
 		}
 		let actions = match handle_application_args(variant) {
 			(HandleLocalStatus::SUCCESS, actions) => actions,
-			(status @ HandleLocalStatus::FAILIURE, _) => return status as i32,
+			(status @ HandleLocalStatus::FAILURE, _) => return status as i32,
 			(status @ HandleLocalStatus::CONTINUE, _) => return status as i32,
 		};
 		// execute the sorted actions

--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -3,7 +3,7 @@ use gtk::glib::{variant::DictEntry, Variant};
 use crate::argtypes::ArgTypes;
 
 pub enum HandleLocalStatus {
-	FAILIURE = 1,
+	FAILURE = 1,
 	SUCCESS = 0,
 	CONTINUE = -1,
 }
@@ -19,7 +19,7 @@ pub(crate) fn handle_application_args(
 
 	if !variant.is_container() {
 		eprintln!("VariantDict isn't a container!...");
-		return (HandleLocalStatus::FAILIURE, actions);
+		return (HandleLocalStatus::FAILURE, actions);
 	}
 
 	for i in 0..variant.n_children() {
@@ -33,21 +33,21 @@ pub(crate) fn handle_application_args(
 				Some(led) => (ArgTypes::CapsLock, Some(led.to_owned())),
 				None => {
 					eprintln!("Value for caps-lock-led isn't a string!...");
-					return (HandleLocalStatus::FAILIURE, actions);
+					return (HandleLocalStatus::FAILURE, actions);
 				}
 			},
 			"num-lock-led" => match child.value().str() {
 				Some(led) => (ArgTypes::NumLock, Some(led.to_owned())),
 				None => {
 					eprintln!("Value for num-lock-led isn't a string!...");
-					return (HandleLocalStatus::FAILIURE, actions);
+					return (HandleLocalStatus::FAILURE, actions);
 				}
 			},
 			"scroll-lock-led" => match child.value().str() {
 				Some(led) => (ArgTypes::ScrollLock, Some(led.to_owned())),
 				None => {
 					eprintln!("Value for scroll-lock-led isn't a string!...");
-					return (HandleLocalStatus::FAILIURE, actions);
+					return (HandleLocalStatus::FAILURE, actions);
 				}
 			},
 			"output-volume" => {
@@ -55,7 +55,7 @@ pub(crate) fn handle_application_args(
 				let parsed = volume_parser(false, value);
 				match parsed {
 					Ok(p) => p,
-					Err(_) => return (HandleLocalStatus::FAILIURE, actions),
+					Err(_) => return (HandleLocalStatus::FAILURE, actions),
 				}
 			}
 			"input-volume" => {
@@ -63,7 +63,7 @@ pub(crate) fn handle_application_args(
 				let parsed = volume_parser(true, value);
 				match parsed {
 					Ok(p) => p,
-					Err(_) => return (HandleLocalStatus::FAILIURE, actions),
+					Err(_) => return (HandleLocalStatus::FAILURE, actions),
 				}
 			}
 			"brightness" => {
@@ -82,7 +82,7 @@ pub(crate) fn handle_application_args(
 					("lower", _) => (ArgTypes::BrightnessLower, None),
 					(e, _) => {
 						eprintln!("Unknown brightness mode: \"{}\"!...", e);
-						return (HandleLocalStatus::FAILIURE, actions);
+						return (HandleLocalStatus::FAILURE, actions);
 					}
 				}
 			}
@@ -92,7 +92,7 @@ pub(crate) fn handle_application_args(
 					Ok(_) => (ArgTypes::MaxVolume, Some(value.to_string())),
 					Err(_) => {
 						eprintln!("{} is not a number between 0 and {}!", value, u8::MAX);
-						return (HandleLocalStatus::FAILIURE, actions);
+						return (HandleLocalStatus::FAILURE, actions);
 					}
 				}
 			}
@@ -101,7 +101,7 @@ pub(crate) fn handle_application_args(
 					Some(v) => v.to_string(),
 					None => {
 						eprintln!("--device found but no name given");
-						return (HandleLocalStatus::FAILIURE, actions);
+						return (HandleLocalStatus::FAILURE, actions);
 					}
 				};
 				(ArgTypes::DeviceName, Some(value))
@@ -114,13 +114,13 @@ pub(crate) fn handle_application_args(
 					}
 					_ => {
 						eprintln!("{} is not a number between 0.0 and 1.0!", value);
-						return (HandleLocalStatus::FAILIURE, actions);
+						return (HandleLocalStatus::FAILURE, actions);
 					}
 				}
 			}
 			e => {
 				eprintln!("Unknown Variant Key: \"{}\"!...", e);
-				return (HandleLocalStatus::FAILIURE, actions);
+				return (HandleLocalStatus::FAILURE, actions);
 			}
 		};
 		if option != ArgTypes::None {

--- a/src/server/application.rs
+++ b/src/server/application.rs
@@ -45,7 +45,7 @@ impl SwayOSDApplication {
 		app.connect_handle_local_options(clone!(@strong osd_app => move |_app, args| {
 			let actions = match handle_application_args(args.to_variant()) {
 				(HandleLocalStatus::SUCCESS | HandleLocalStatus::CONTINUE, actions) => actions,
-				(status @ HandleLocalStatus::FAILIURE, _) => return status as i32,
+				(status @ HandleLocalStatus::FAILURE, _) => return status as i32,
 			};
 			for (arg_type, data) in actions {
 				match (arg_type, data) {

--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -9,7 +9,7 @@ use gtk::{
 };
 use pulsectl::controllers::types::DeviceInfo;
 
-use crate::utils::{get_top_margin, volume_to_f64, KeysLocks, VolumeDeviceType};
+use crate::utils::{get_max_volume, get_top_margin, volume_to_f64, KeysLocks, VolumeDeviceType};
 use blight::Device;
 
 const ICON_SIZE: i32 = 32;
@@ -92,8 +92,10 @@ impl SwayosdWindow {
 		};
 		let icon_name = &format!("{}-volume-{}-symbolic", icon_prefix, icon_state);
 
+		let max_volume: f64 = get_max_volume().into();
+
 		let icon = self.build_icon_widget(icon_name);
-		let progress = self.build_progress_widget(volume / 100.0);
+		let progress = self.build_progress_widget(volume / max_volume);
 
 		progress.set_sensitive(!device.mute);
 


### PR DESCRIPTION
Adjusts the volume progress bar to account for overamplification based on the `max-volume` argument.

This is a simple fix. It would be nice if the portion of the bar that is over 100% were distinguished in some way (different color or style) as Gnome does it. I couldn't figure out a quick way to do this though. I think we'd need two progress bars next to each other to be able to set a different color on the second bar.

Implements #44
