### PR TITLE
make background adapt to gtk theme

### DIFF
--- a/data/style/style.css
+++ b/data/style/style.css
@@ -2,6 +2,7 @@ window {
     padding: 12px 20px;
     border-radius: 999px;
     border: none;
+    background: alpha(@theme_bg_color, 0.8);
 }
 
 #container {


### PR DESCRIPTION
This simple change fixes #58.

Since the default `style.css` uses `@theme_fg_color` for the images and labels, this PR uses `@theme_bg_color` for the background.
This will also alter the "default" dark look so that it does not look exactly like the images in the readme.

Here is what it looks like with Adwaita and Adwaita-dark respectively:
![light_cropped](https://github.com/ErikReider/SwayOSD/assets/9250536/c159a840-c87d-439f-bcf2-ba5f0c2a80a5)

![dark_cropped](https://github.com/ErikReider/SwayOSD/assets/9250536/7dc935d4-3b1b-4ffa-b613-3dcc7e823294)
