### PR TITLE
Fix bug related to blight and add a feature for brightness

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ bindsym XF86MonBrightnessUp exec swayosd-client --brightness raise
 # Brightness lower
 bindsym XF86MonBrightnessDown exec swayosd-client --brightness lower
 
-# Brightness raise with custom value
-bindsym XF86MonBrightnessUp  exec swayosd-client --brightness 10
-# Brightness lower with custom value
+# Brightness raise with custom value('+' sign needed)
+bindsym XF86MonBrightnessUp  exec swayosd-client --brightness +10
+# Brightness lower with custom value('-' sign needed)
 bindsym XF86MonBrightnessDown exec swayosd-client --brightness -10
 ```
 

--- a/src/brightness_backend/blight.rs
+++ b/src/brightness_backend/blight.rs
@@ -16,6 +16,7 @@ impl BrightnessBackendConstructor for Blight {
 
 impl BrightnessBackend for Blight {
 	fn get_current(&mut self) -> u32 {
+		self.device.reload();
 		self.device.current()
 	}
 

--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -68,9 +68,22 @@ pub(crate) fn handle_application_args(
 			}
 			"brightness" => {
 				let value = child.value().str().unwrap_or("");
+				let coef = if value.starts_with('+') {
+					1
+				} else if value.starts_with('-') {
+					-1
+				} else {
+					0
+				};
+
 				match (value, value.parse::<i8>()) {
 					// Parse custom step values
-					(_, Ok(num)) => (ArgTypes::BrightnessSet, Some(num.abs().to_string())),
+					(_, Ok(num)) if coef == 1 => (ArgTypes::BrightnessRaise, Some(num.to_string())),
+					(_, Ok(num)) if coef == -1 => {
+						(ArgTypes::BrightnessLower, Some(num.abs().to_string()))
+					}
+					(_, Ok(num)) if coef == 0 => (ArgTypes::BrightnessSet, Some(num.to_string())),
+
 					("raise", _) => (ArgTypes::BrightnessRaise, None),
 					("lower", _) => (ArgTypes::BrightnessLower, None),
 					(e, _) => {

--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -68,12 +68,11 @@ pub(crate) fn handle_application_args(
 			}
 			"brightness" => {
 				let value = child.value().str().unwrap_or("");
-				let coef = if value.starts_with('+') {
-					1
-				} else if value.starts_with('-') {
-					-1
-				} else {
-					0
+
+				let coef: i32 = match value.get(..1) {
+					Some("+") => 1,
+					Some("-") => -1,
+					_ => 0,
 				};
 
 				match (value, value.parse::<i8>()) {

--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -78,11 +78,11 @@ pub(crate) fn handle_application_args(
 
 				match (value, value.parse::<i8>()) {
 					// Parse custom step values
-					(_, Ok(num)) if coef == 1 => (ArgTypes::BrightnessRaise, Some(num.to_string())),
-					(_, Ok(num)) if coef == -1 => {
-						(ArgTypes::BrightnessLower, Some(num.abs().to_string()))
-					}
-					(_, Ok(num)) if coef == 0 => (ArgTypes::BrightnessSet, Some(num.to_string())),
+					(_, Ok(num)) => match coef {
+						1 => (ArgTypes::BrightnessRaise, Some(num.to_string())),
+						-1 => (ArgTypes::BrightnessLower, Some(num.abs().to_string())),
+						_ => (ArgTypes::BrightnessSet, Some(num.to_string())),
+					},
 
 					("raise", _) => (ArgTypes::BrightnessRaise, None),
 					("lower", _) => (ArgTypes::BrightnessLower, None),


### PR DESCRIPTION
When using this program I noticed that when changing brightness quickly(ex: raise it two times and then lower it), the indicator(osd bar) would not reflect these changes(in case of the previous example it would raise when I lower the brightness). So I found out that the current brightness of the blight device does not update properly. Reloading the device current value solved this issue.
Another problem I found is that there was no way to change the brightness by a custom delta anymore(this was possible before), so I added some code that checks if the argument is signed or not and applies the changes(if there's no sign, then that means the user wants to set the brightness to that value).
LE: This PR fixes [#68](https://github.com/ErikReider/SwayOSD/issues/68).