### PR TITLE
Add percentage labels to volume and brightness indicators

### DIFF
--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -15,6 +15,7 @@ pub struct ServerConfig {
 	pub style: Option<PathBuf>,
 	pub top_margin: Option<f32>,
 	pub max_volume: Option<u8>,
+	pub show_percentage: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug)]

--- a/src/server/application.rs
+++ b/src/server/application.rs
@@ -70,6 +70,9 @@ impl SwayOSDApplication {
 		if let Some(max_volume) = server_config.max_volume {
 			set_default_max_volume(max_volume);
 		}
+		if let Some(show) = server_config.show_percentage {
+			set_show_percentage(show);
+		}
 
 		// Parse args
 		app.connect_handle_local_options(clone!(@strong osd_app => move |_app, args| {

--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -99,11 +99,13 @@ impl SwayosdWindow {
 
 		let icon = self.build_icon_widget(icon_name);
 		let progress = self.build_progress_widget(volume / max_volume);
+		let label = self.build_text_widget(Some(&format!("{}%", volume)));
 
 		progress.set_sensitive(!device.mute);
 
 		self.container.add(&icon);
 		self.container.add(&progress);
+		self.container.add(&label);
 
 		self.run_timeout();
 	}
@@ -117,9 +119,11 @@ impl SwayosdWindow {
 		let brightness = brightness_backend.get_current() as f64;
 		let max = brightness_backend.get_max() as f64;
 		let progress = self.build_progress_widget(brightness / max);
+		let label = self.build_text_widget(Some(&format!("{}%", (brightness / max * 100.) as i32)));
 
 		self.container.add(&icon);
 		self.container.add(&progress);
+		self.container.add(&label);
 
 		self.run_timeout();
 	}

--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -11,7 +11,10 @@ use pulsectl::controllers::types::DeviceInfo;
 
 use crate::{
 	brightness_backend::BrightnessBackend,
-	utils::{get_max_volume, get_top_margin, volume_to_f64, KeysLocks, VolumeDeviceType},
+	utils::{
+		get_max_volume, get_show_percentage, get_top_margin, volume_to_f64, KeysLocks,
+		VolumeDeviceType,
+	},
 };
 
 const ICON_SIZE: i32 = 32;
@@ -105,7 +108,9 @@ impl SwayosdWindow {
 
 		self.container.add(&icon);
 		self.container.add(&progress);
-		self.container.add(&label);
+		if get_show_percentage() {
+			self.container.add(&label);
+		}
 
 		self.run_timeout();
 	}
@@ -123,7 +128,9 @@ impl SwayosdWindow {
 
 		self.container.add(&icon);
 		self.container.add(&progress);
-		self.container.add(&label);
+		if get_show_percentage() {
+			self.container.add(&label);
+		}
 
 		self.run_timeout();
 	}

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -23,6 +23,7 @@ lazy_static! {
 	static ref DEVICE_NAME: Mutex<Option<String>> = Mutex::new(None);
 	pub static ref TOP_MARGIN_DEFAULT: f32 = 0.85_f32;
 	static ref TOP_MARGIN: Mutex<f32> = Mutex::new(*TOP_MARGIN_DEFAULT);
+	pub static ref SHOW_PERCENTAGE: Mutex<bool> = Mutex::new(false);
 }
 
 pub enum KeysLocks {
@@ -61,6 +62,15 @@ pub fn get_top_margin() -> f32 {
 pub fn set_top_margin(margin: f32) {
 	let mut margin_mut = TOP_MARGIN.lock().unwrap();
 	*margin_mut = margin;
+}
+
+pub fn get_show_percentage() -> bool {
+	*SHOW_PERCENTAGE.lock().unwrap()
+}
+
+pub fn set_show_percentage(show: bool) {
+	let mut show_mut = SHOW_PERCENTAGE.lock().unwrap();
+	*show_mut = show;
 }
 
 pub fn get_device_name() -> Option<String> {


### PR DESCRIPTION
This PR adds a textual percentage next to the progress bar in the volume and brightness indicators. This is useful for users who still want to know the exact volume percentage set in practice.

This is off by default and can be enabled with the `show_percentage` boolean setting in the `[server]` block in `CONFIG_HOME/swayosd/config.toml`.

Example config:

```
# ~/.config/swayosd/config.toml
[server]
show_percentage = true
```