### PR TITLE
Fix Raise/lower brightness by specific amount

### DIFF
--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -73,11 +73,10 @@ pub(crate) fn handle_application_args(
 					(_, Ok(num)) => {
 						if !value.contains('+') && !value.contains('-') {
 							(ArgTypes::BrightnessSet, Some(num.abs().to_string()))
-						}
-						else if num < 0 {
+						} else if num < 0 {
 							(ArgTypes::BrightnessLower, Some(num.abs().to_string()))
 						} else {
-                            (ArgTypes::BrightnessRaise, Some(num.to_string()))
+							(ArgTypes::BrightnessRaise, Some(num.to_string()))
 						}
 					}
 					("raise", _) => (ArgTypes::BrightnessRaise, None),

--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -68,9 +68,16 @@ pub(crate) fn handle_application_args(
 			}
 			"brightness" => {
 				let value = child.value().str().unwrap_or("");
-				match (value, value.parse::<i8>()) {
+
+				match (value, value.parse::<i16>()) {
 					// Parse custom step values
-					(_, Ok(num)) => (ArgTypes::BrightnessSet, Some(num.abs().to_string())),
+					(_, Ok(num)) => {
+						if num < 0 {
+							(ArgTypes::BrightnessLower, Some(num.abs().to_string()))
+						} else {
+							(ArgTypes::BrightnessRaise, Some(num.to_string()))
+						}
+					}
 					("raise", _) => (ArgTypes::BrightnessRaise, None),
 					("lower", _) => (ArgTypes::BrightnessLower, None),
 					(e, _) => {

--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -70,7 +70,6 @@ pub(crate) fn handle_application_args(
 				let value = child.value().str().unwrap_or("");
 
 				match (value, value.parse::<i8>()) {
-					// Parse custom step values
 					(_, Ok(num)) => {
 						if !value.contains('+') && !value.contains('-') {
 							(ArgTypes::BrightnessSet, Some(num.abs().to_string()))

--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -69,7 +69,7 @@ pub(crate) fn handle_application_args(
 			"brightness" => {
 				let value = child.value().str().unwrap_or("");
 
-				match (value, value.parse::<i16>()) {
+				match (value, value.parse::<i8>()) {
 					// Parse custom step values
 					(_, Ok(num)) => {
 						if num < 0 {

--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -72,10 +72,13 @@ pub(crate) fn handle_application_args(
 				match (value, value.parse::<i8>()) {
 					// Parse custom step values
 					(_, Ok(num)) => {
-						if num < 0 {
+						if !value.contains('+') && !value.contains('-') {
+							(ArgTypes::BrightnessSet, Some(num.abs().to_string()))
+						}
+						else if num < 0 {
 							(ArgTypes::BrightnessLower, Some(num.abs().to_string()))
 						} else {
-							(ArgTypes::BrightnessRaise, Some(num.to_string()))
+                            (ArgTypes::BrightnessRaise, Some(num.to_string()))
 						}
 					}
 					("raise", _) => (ArgTypes::BrightnessRaise, None),


### PR DESCRIPTION
This PR resolves #68, where the `--brightness +n|-n` option ignored the prefixes of the given number and running set instead of raise/lower.

What I changed is the following:
 - Instead of parsing a u8 for the brightness, parse an i8 (for negative numbers)
 - Extra conditional logic: if we parsed the number to an i8, check the original string:
    - If the string doesn't contain a + or -, we call the set brightness function with the i8.
    - If the string does contain a + or -, we check if the number is positive or negative and call the raise or lower brightness
       function.

I've tested the brightness functionality on my machine, and it works correctly.

Let me know if I need to change anything.