### PR TITLE
Add config file and implement config file parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.12",
 ]
 
 [[package]]
@@ -1505,9 +1505,12 @@ dependencies = [
  "libpulse-binding",
  "nix",
  "pulsectl-rs",
+ "serde",
+ "serde_derive",
  "shrinkwraprs",
  "substring",
  "thiserror",
+ "toml 0.8.2",
  "zbus",
 ]
 
@@ -1542,7 +1545,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml",
+ "toml 0.7.6",
  "version-compare",
 ]
 
@@ -1595,7 +1598,19 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.12",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -1617,7 +1632,20 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.4.9",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -1884,6 +1912,15 @@ name = "winnow"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/input-backend/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# Config dependencies
+toml = "0.8"
+serde = "1"
+serde_derive = "1"
 # GUI Dependencies
 gtk = "0.17.1"
 gtk-layer-shell = "0.6.1"

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -30,6 +30,11 @@ pub fn get_proxy() -> zbus::Result<ServerProxyBlocking<'static>> {
 }
 
 fn main() -> Result<(), glib::Error> {
+	// Parse Config
+	let _client_config = config::user::read_user_config()
+		.expect("Failed to parse config file")
+		.client;
+
 	// Make sure that the server is running
 	let proxy = match get_proxy() {
 		Ok(proxy) => match proxy.introspect() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,10 @@
 #![allow(dead_code)]
 
+#[path = "config/backend.rs"]
+pub mod backend;
+#[path = "config/user.rs"]
+pub mod user;
+
 pub const DBUS_PATH: &str = "/org/erikreider/swayosd";
 pub const DBUS_BACKEND_NAME: &str = "org.erikreider.swayosd";
 pub const DBUS_SERVER_NAME: &str = "org.erikreider.swayosd-server";

--- a/src/config/backend.rs
+++ b/src/config/backend.rs
@@ -1,0 +1,37 @@
+use gtk::glib::system_config_dirs;
+use serde_derive::Deserialize;
+use std::error::Error;
+use std::path::PathBuf;
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct InputBackendConfig {}
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct BackendConfig {
+	#[serde(default)]
+	pub input: InputBackendConfig,
+}
+
+fn find_backend_config() -> Option<PathBuf> {
+	for path in system_config_dirs() {
+		let path = path.join("swayosd").join("backend.toml");
+		if path.exists() {
+			return Some(path);
+		}
+	}
+
+	None
+}
+
+pub fn read_backend_config() -> Result<BackendConfig, Box<dyn Error>> {
+	let path = match find_backend_config() {
+		Some(path) => path,
+		None => return Ok(Default::default()),
+	};
+
+	let config_file = std::fs::read_to_string(path)?;
+	let config: BackendConfig = toml::from_str(&config_file)?;
+	Ok(config)
+}

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -2,6 +2,7 @@ use gtk::glib::system_config_dirs;
 use gtk::glib::user_config_dir;
 use serde_derive::Deserialize;
 use std::error::Error;
+use std::path::Path;
 use std::path::PathBuf;
 
 #[derive(Deserialize, Default, Debug)]
@@ -41,8 +42,8 @@ fn find_user_config() -> Option<PathBuf> {
 	None
 }
 
-pub fn read_user_config() -> Result<UserConfig, Box<dyn Error>> {
-	let path = match find_user_config() {
+pub fn read_user_config(path: Option<&Path>) -> Result<UserConfig, Box<dyn Error>> {
+	let path = match path.map(Path::to_owned).or_else(find_user_config) {
 		Some(path) => path,
 		None => return Ok(Default::default()),
 	};

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -1,0 +1,53 @@
+use gtk::glib::system_config_dirs;
+use gtk::glib::user_config_dir;
+use serde_derive::Deserialize;
+use std::error::Error;
+use std::path::PathBuf;
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct ClientConfig {}
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct ServerConfig {
+	pub style: Option<PathBuf>,
+	pub top_margin: Option<f32>,
+	pub max_volume: Option<u8>,
+}
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct UserConfig {
+	#[serde(default)]
+	pub server: ServerConfig,
+	#[serde(default)]
+	pub client: ClientConfig,
+}
+
+fn find_user_config() -> Option<PathBuf> {
+	let path = user_config_dir().join("swayosd").join("config.toml");
+	if path.exists() {
+		return Some(path);
+	}
+
+	for path in system_config_dirs() {
+		let path = path.join("swayosd").join("config.toml");
+		if path.exists() {
+			return Some(path);
+		}
+	}
+
+	None
+}
+
+pub fn read_user_config() -> Result<UserConfig, Box<dyn Error>> {
+	let path = match find_user_config() {
+		Some(path) => path,
+		None => return Ok(Default::default()),
+	};
+
+	let config_file = std::fs::read_to_string(path)?;
+	let config: UserConfig = toml::from_str(&config_file)?;
+	Ok(config)
+}

--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -118,6 +118,7 @@ pub(crate) fn handle_application_args(
 				}
 			}
 			"style" => continue,
+			"config" => continue,
 			e => {
 				eprintln!("Unknown Variant Key: \"{}\"!...", e);
 				return (HandleLocalStatus::FAILURE, actions);

--- a/src/input-backend/main.rs
+++ b/src/input-backend/main.rs
@@ -42,6 +42,11 @@ impl LibinputInterface for Interface {
 }
 
 fn main() -> Result<(), zbus::Error> {
+	// Parse Config
+	let _input_config = config::backend::read_backend_config()
+		.expect("Failed to parse config file")
+		.input;
+
 	// Create DBUS server
 	let connection = task::block_on(DbusServer.init());
 	let object_server = connection.object_server();

--- a/src/server/application.rs
+++ b/src/server/application.rs
@@ -27,6 +27,15 @@ impl SwayOSDApplication {
 		let app = Application::new(Some(APPLICATION_NAME), ApplicationFlags::FLAGS_NONE);
 
 		app.add_main_option(
+			"config",
+			glib::Char::from(0),
+			OptionFlags::NONE,
+			OptionArg::String,
+			"Use a custom config file instead of looking for one.",
+			Some("<CONFIG FILE PATH>"),
+		);
+
+		app.add_main_option(
 			"style",
 			glib::Char::from('s' as u8),
 			OptionFlags::NONE,

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -79,6 +79,11 @@ fn main() {
 		std::process::exit(1);
 	}
 
+	// Parse Config
+	let server_config = config::user::read_user_config()
+		.expect("Failed to parse config file")
+		.server;
+
 	// Load the compiled resource bundle
 	let resources_bytes = include_bytes!(concat!(env!("OUT_DIR"), "/swayosd.gresource"));
 	let resource_data = Bytes::from(&resources_bytes[..]);
@@ -107,7 +112,7 @@ fn main() {
 	}
 
 	// Try loading the users CSS theme
-	let mut custom_user_css: Option<PathBuf> = None;
+	let mut custom_user_css: Option<PathBuf> = server_config.style.clone();
 	let mut args = args_os().into_iter();
 	while let Some(arg) = args.next() {
 		match arg.to_str() {
@@ -135,5 +140,5 @@ fn main() {
 	// Start the DBus Server
 	async_std::task::spawn(DbusServer::new(sender));
 	// Start the GTK Application
-	std::process::exit(SwayOSDApplication::new(receiver).start());
+	std::process::exit(SwayOSDApplication::new(server_config, receiver).start());
 }


### PR DESCRIPTION
This PR adds a TOML config file for the server, client, and libinput backend.

There are two config files
-  `<SYSTEM_CONFIG_DIRS>/swayosd/backend.toml` for the backend components that run with elevated privileges. This file should never be read from a user configuration folder.
- `<SYSTEM_CONFIG_DIRS>/swayosd/config.toml` or `<USER_CONFIG_DIR>/swayosd/config.toml` for the server and client that run as the user. This file should be read from the user configuration folder if it exists and fall back to the system configuration directories otherwise


The config files are structured like this:

## Backend configuration
```toml
[input]
# libinput backend configuration options (none so far)

# ... sections for future backend components that need elevated privileges ...
# [foo]
# bar = "baz"
```

## Server and Client configuration
```toml
[server]
style = "/path/to/my/style.css"
top_margin = 0.85
# show_percentage = true (once #69 is merged)

[client]
# client configuration options (none so far)
```

## Implementation Design

The parsing uses [serde](https://docs.rs/serde/latest/serde/) and [toml](https://docs.rs/toml/latest/toml/) to parse the TOML file directly into a struct.

Sections and options in the config file are optional, but misspelling them is an error.

Fixes #42.