### PR TITLE
Add support for custom messages with icons

### DIFF
--- a/src/argtypes.rs
+++ b/src/argtypes.rs
@@ -7,7 +7,7 @@ pub enum ArgTypes {
 	DeviceName = isize::MIN,
 	TopMargin = isize::MIN + 1,
 	MaxVolume = isize::MIN + 2,
-	CustomIcon = isize::MIN + 4,
+	CustomIcon = isize::MIN + 3,
 	// Other
 	None = 0,
 	CapsLock = 1,

--- a/src/argtypes.rs
+++ b/src/argtypes.rs
@@ -7,6 +7,7 @@ pub enum ArgTypes {
 	DeviceName = isize::MIN,
 	TopMargin = isize::MIN + 1,
 	MaxVolume = isize::MIN + 2,
+	CustomIcon = isize::MIN + 4,
 	// Other
 	None = 0,
 	CapsLock = 1,
@@ -21,6 +22,7 @@ pub enum ArgTypes {
 	BrightnessSet = 12,
 	NumLock = 10,
 	ScrollLock = 11,
+	CustomMessage = 13,
 }
 
 impl fmt::Display for ArgTypes {
@@ -42,6 +44,8 @@ impl fmt::Display for ArgTypes {
 			ArgTypes::ScrollLock => "SCROLL-LOCK",
 			ArgTypes::DeviceName => "DEVICE-NAME",
 			ArgTypes::TopMargin => "TOP-MARGIN",
+			ArgTypes::CustomMessage => "CUSTOM-MESSAGE",
+			ArgTypes::CustomIcon => "CUSTOM-ICON",
 		};
 		return write!(f, "{}", string);
 	}
@@ -67,6 +71,8 @@ impl str::FromStr for ArgTypes {
 			"SCROLL-LOCK" => ArgTypes::ScrollLock,
 			"DEVICE-NAME" => ArgTypes::DeviceName,
 			"TOP-MARGIN" => ArgTypes::TopMargin,
+			"CUSTOM-MESSAGE" => ArgTypes::CustomMessage,
+			"CUSTOM-ICON" => ArgTypes::CustomIcon,
 			other_type => return Err(other_type.to_owned()),
 		};
 		Ok(result)

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -173,6 +173,24 @@ fn main() -> Result<(), glib::Error> {
 		Some("Pulseaudio device name (pactl list short sinks|sources)"),
 	);
 
+	app.add_main_option(
+		"custom-message",
+		glib::Char::from(0),
+		OptionFlags::NONE,
+		OptionArg::String,
+		"Message to display",
+		Some("text"),
+	);
+
+	app.add_main_option(
+		"custom-icon",
+		glib::Char::from(0),
+		OptionFlags::NONE,
+		OptionArg::String,
+		"Icon to display when using custom-message. Icon name is from Freedesktop specification (https://specifications.freedesktop.org/icon-naming-spec/latest/)",
+		Some("Icon name"),
+	);
+
 	// Parse args
 	app.connect_handle_local_options(move |_app, args| {
 		let variant = args.to_variant();

--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -105,6 +105,26 @@ pub(crate) fn handle_application_args(
 				};
 				(ArgTypes::DeviceName, Some(value))
 			}
+			"custom-message" => {
+				let value = match child.value().str() {
+					Some(v) => v.to_string(),
+					None => {
+						eprintln!("--custom-message found but no message given");
+						return (HandleLocalStatus::FAILURE, actions);
+					}
+				};
+				(ArgTypes::CustomMessage, Some(value))
+			}
+			"custom-icon" => {
+				let value = match child.value().str() {
+					Some(v) => v.to_string(),
+					None => {
+						eprintln!("--custom-icon found but no icon given");
+						return (HandleLocalStatus::FAILURE, actions);
+					}
+				};
+				(ArgTypes::CustomIcon, Some(value))
+			}
 			"top-margin" => {
 				let value = child.value().str().unwrap_or("").trim();
 				match value.parse::<f32>() {

--- a/src/server/application.rs
+++ b/src/server/application.rs
@@ -342,6 +342,17 @@ impl SwayOSDApplication {
 			(ArgTypes::DeviceName, name) => {
 				set_device_name(name.unwrap_or(DEVICE_NAME_DEFAULT.to_string()))
 			}
+			(ArgTypes::CustomMessage, message) => {
+				if let Some(message) = message {
+					for window in osd_app.windows.borrow().to_owned() {
+						window.custom_message(message.as_str(), get_icon_name().as_deref());
+					}
+				}
+				reset_icon_name();
+			}
+			(ArgTypes::CustomIcon, icon) => {
+				set_icon_name(icon.unwrap_or(ICON_NAME_DEFAULT.to_string()))
+			}
 			(arg_type, data) => {
 				eprintln!(
 					"Failed to parse command... Type: {:?}, Data: {:?}",

--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -174,6 +174,20 @@ impl SwayosdWindow {
 		self.run_timeout();
 	}
 
+	pub fn custom_message(&self, message: &str, icon_name: Option<&str>) {
+		self.clear_osd();
+
+		if let Some(icon_name) = icon_name {
+			let icon = self.build_icon_widget(icon_name);
+			self.container.add(&icon);
+		}
+
+		let label = self.build_text_widget(Some(message));
+		self.container.add(&label);
+
+		self.run_timeout();
+	}
+
 	/// Clear all container children
 	fn clear_osd(&self) {
 		for widget in self.container.children() {

--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -177,13 +177,21 @@ impl SwayosdWindow {
 	pub fn custom_message(&self, message: &str, icon_name: Option<&str>) {
 		self.clear_osd();
 
+		let label = self.build_text_widget(Some(message));
+
 		if let Some(icon_name) = icon_name {
 			let icon = self.build_icon_widget(icon_name);
 			self.container.add(&icon);
+			self.container.add(&label);
+			let box_spacing = self.container.spacing();
+			icon.connect_size_allocate(move |icon, allocate| {
+				label.set_margin_end(
+					allocate.width() + icon.margin_start() + icon.margin_end() + box_spacing,
+				);
+			});
+		} else {
+			self.container.add(&label);
 		}
-
-		let label = self.build_text_widget(Some(message));
-		self.container.add(&label);
 
 		self.run_timeout();
 	}

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -21,6 +21,8 @@ lazy_static! {
 	static ref MAX_VOLUME: Mutex<u8> = Mutex::new(PRIV_MAX_VOLUME_DEFAULT);
 	pub static ref DEVICE_NAME_DEFAULT: &'static str = "default";
 	static ref DEVICE_NAME: Mutex<Option<String>> = Mutex::new(None);
+	pub static ref ICON_NAME_DEFAULT: &'static str = "text-x-generic";
+	static ref ICON_NAME: Mutex<Option<String>> = Mutex::new(None);
 	pub static ref TOP_MARGIN_DEFAULT: f32 = 0.85_f32;
 	static ref TOP_MARGIN: Mutex<f32> = Mutex::new(*TOP_MARGIN_DEFAULT);
 	pub static ref SHOW_PERCENTAGE: Mutex<bool> = Mutex::new(false);
@@ -85,6 +87,20 @@ pub fn set_device_name(name: String) {
 pub fn reset_device_name() {
 	let mut global_name = DEVICE_NAME.lock().unwrap();
 	*global_name = None;
+}
+
+pub fn get_icon_name() -> Option<String> {
+	(*ICON_NAME.lock().unwrap()).clone()
+}
+
+pub fn set_icon_name(name: String) {
+	let mut icon_name = ICON_NAME.lock().unwrap();
+	*icon_name = Some(name);
+}
+
+pub fn reset_icon_name() {
+	let mut icon_name = ICON_NAME.lock().unwrap();
+	*icon_name = None;
 }
 
 pub fn get_key_lock_state(key: KeysLocks, led: Option<String>) -> bool {


### PR DESCRIPTION
This PR adds support for displaying arbitrary text messages and icons, which opens up the possible use cases immensely. For example, I use this to display a message when I change my keyboard layout.

![Untitled](https://github.com/user-attachments/assets/77322e41-cb19-47c0-be9c-dfb0e1071882)

This is done by adding two CLI options, `--custom-message` and `--custom-icon`.

Closes #86.
