### PR TITLE
zbus: move to non-deprecated attribute macros

### DIFF
--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -15,9 +15,9 @@ use gtk::{gio::ApplicationFlags, Application};
 use gtk::{glib, prelude::*};
 use std::env::args_os;
 use std::path::PathBuf;
-use zbus::{blocking::Connection, dbus_proxy};
+use zbus::{blocking::Connection, proxy};
 
-#[dbus_proxy(
+#[proxy(
 	interface = "org.erikreider.swayosd",
 	default_service = "org.erikreider.swayosd-server",
 	default_path = "/org/erikreider/swayosd"

--- a/src/input-backend/dbus_server.rs
+++ b/src/input-backend/dbus_server.rs
@@ -1,12 +1,12 @@
-use zbus::{dbus_interface, Connection, ConnectionBuilder, SignalContext};
+use zbus::{interface, Connection, ConnectionBuilder, SignalContext};
 
 use crate::config::{DBUS_BACKEND_NAME, DBUS_PATH};
 
 pub struct DbusServer;
 
-#[dbus_interface(name = "org.erikreider.swayosd")]
+#[interface(name = "org.erikreider.swayosd")]
 impl DbusServer {
-	#[dbus_interface(signal)]
+	#[zbus(signal)]
 	pub async fn key_pressed(
 		signal_ctxt: &SignalContext<'_>,
 		key_code: u16,

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -35,13 +35,13 @@ use std::future::pending;
 use std::path::PathBuf;
 use std::str::FromStr;
 use utils::{get_system_css_path, user_style_path};
-use zbus::{dbus_interface, ConnectionBuilder};
+use zbus::{interface, ConnectionBuilder};
 
 struct DbusServer {
 	sender: Sender<(ArgTypes, String)>,
 }
 
-#[dbus_interface(name = "org.erikreider.swayosd")]
+#[interface(name = "org.erikreider.swayosd")]
 impl DbusServer {
 	pub fn handle_action(&self, arg_type: String, data: String) -> bool {
 		let arg_type = match ArgTypes::from_str(&arg_type) {


### PR DESCRIPTION
This fixes the zbus deprecation warnings from using the old `zbus::dbus_server` and `zbus::dbus_proxy` APIs. The new ones don't have the `dbus_` prefix and sometimes need item attributes to identify handlers or arguments.

This doesn't change anything feature-wise, so should be good to merge.