### PR TITLE
Fix swayosd-server exiting when no monitors exist (e.g. on switch to another tty)

### DIFF
--- a/src/server/application.rs
+++ b/src/server/application.rs
@@ -27,11 +27,13 @@ pub struct SwayOSDApplication {
 	#[shrinkwrap(main_field)]
 	app: gtk::Application,
 	windows: Rc<RefCell<Vec<SwayosdWindow>>>,
+	_hold: Rc<gio::ApplicationHoldGuard>,
 }
 
 impl SwayOSDApplication {
 	pub fn new(server_config: ServerConfig, action_receiver: Receiver<(ArgTypes, String)>) -> Self {
 		let app = Application::new(Some(APPLICATION_NAME), ApplicationFlags::FLAGS_NONE);
+		let hold = Rc::new(app.hold());
 
 		app.add_main_option(
 			"config",
@@ -66,6 +68,7 @@ impl SwayOSDApplication {
 		let osd_app = SwayOSDApplication {
 			app: app.clone(),
 			windows: Rc::new(RefCell::new(Vec::new())),
+			_hold: hold,
 		};
 
 		// Apply Server Config


### PR DESCRIPTION
This PR fixes a bug that caused swayosd-server to exit when switching TTYs. I'm not sure if this was the case before the GTK4 port, but this PR fixes it.

The GApplication exits when the last window is closed, which in swayosd-server is when all monitors disappear, which happens when you switch TTYs. Counteract this by always keeping a reference to the GApplication, which avoids this. Since swayosd-server is a daemon, the normal behaviour of exiting after the last window is gone is unwanted.