### PR TITLE
[server] option to ignore caps lock, fixes #41

### DIFF
--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -9,13 +9,14 @@ use std::path::PathBuf;
 #[serde(deny_unknown_fields)]
 pub struct ClientConfig {}
 
-#[derive(Deserialize, Default, Debug)]
+#[derive(Deserialize, Default, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ServerConfig {
 	pub style: Option<PathBuf>,
 	pub top_margin: Option<f32>,
 	pub max_volume: Option<u8>,
 	pub show_percentage: Option<bool>,
+	pub ignore_caps_lock: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug)]

--- a/src/server/application.rs
+++ b/src/server/application.rs
@@ -28,6 +28,7 @@ pub struct SwayOSDApplication {
 	app: gtk::Application,
 	windows: Rc<RefCell<Vec<SwayosdWindow>>>,
 	_hold: Rc<gio::ApplicationHoldGuard>,
+	server_config: ServerConfig,
 }
 
 impl SwayOSDApplication {
@@ -69,6 +70,7 @@ impl SwayOSDApplication {
 			app: app.clone(),
 			windows: Rc::new(RefCell::new(Vec::new())),
 			_hold: hold,
+			server_config: server_config.clone(),
 		};
 
 		// Apply Server Config
@@ -347,13 +349,15 @@ impl SwayOSDApplication {
 				}
 			}
 			(ArgTypes::CapsLock, value) => {
-				let i32_value = value.clone().unwrap_or("-1".to_owned());
-				let state = match i32_value.parse::<i32>() {
-					Ok(value) if value >= 0 && value <= 1 => value == 1,
-					_ => get_key_lock_state(KeysLocks::CapsLock, value),
-				};
-				for window in osd_app.windows.borrow().to_owned() {
-					window.changed_keylock(KeysLocks::CapsLock, state)
+				if ! osd_app.server_config.ignore_caps_lock.unwrap_or(false) {
+					let i32_value = value.clone().unwrap_or("-1".to_owned());
+					let state = match i32_value.parse::<i32>() {
+						Ok(value) if value >= 0 && value <= 1 => value == 1,
+						_ => get_key_lock_state(KeysLocks::CapsLock, value),
+					};
+					for window in osd_app.windows.borrow().to_owned() {
+						window.changed_keylock(KeysLocks::CapsLock, state)
+					}
 				}
 			}
 			(ArgTypes::NumLock, value) => {


### PR DESCRIPTION
No idea if this is a good approach[0], but it works for me.

`~/.config/swayosd/config.toml` set to

```
[server]
ignore_caps_lock = true
```

[0] I think in an ideal world we would ignore the capslock _key_ and instead monitor the capslock _status_[1], but I have no idea how one would do that

[1] I do actually like having a capslock _status_ notifier - the reason I'm adding in support to ignore the capslock key is that I have the capslock key aliased to `escape`, so it no longer has anything to do with the capslock _status_