### PR TITLE
[backend] option to ignore caps lock, fixes #41

### DIFF
--- a/src/config/backend.rs
+++ b/src/config/backend.rs
@@ -5,7 +5,9 @@ use std::path::PathBuf;
 
 #[derive(Deserialize, Default, Debug)]
 #[serde(deny_unknown_fields)]
-pub struct InputBackendConfig {}
+pub struct InputBackendConfig {
+	pub ignore_caps_lock_key: Option<bool>,
+}
 
 #[derive(Deserialize, Default, Debug)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
No idea if this is a good approach[0], but it works for me.

`/etc/xdg/swayosd/backend.toml` set to

```
[input]
ignore_caps_lock_key = true
```

[0] I think in an ideal world we would ignore the capslock key and instead monitor the capslock status[1], but I have no idea how one would do that

[1] I do actually like having a capslock status notifier - the reason I'm adding in support to ignore the capslock key is that I have the capslock key aliased to `escape`, so it no longer has anything to do with the capslock status