### PR TITLE
feat: add --monitor parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ bindsym XF86MonBrightnessDown exec swayosd-client --brightness -10
 - It only changes the target device for the current action that changes the volume.
 - You can list your input audio devices using `pactl list short sources`, for outputs replace `sources` with `sinks`.
 
+### Notes on using `--monitor`:
+
+- By default, without using --monitor the osd will be shown on all monitors
+- On setups with multiple monitors, if you only want to show the osd on the focused monitor, you can do so with the help of window manager specific commands:
+```sh
+# Sway
+swayosd-client --monitor "$(swaymsg -t get_outputs | jq -r '.[] | select(.focused == true).name')" --output-volume raise
+
+# Hyprland
+swayosd-client --monitor "$(hyprctl monitors -j | jq -r '.[] | select(.focused == true).name')" --output-volume raise
+```
+
 ## Theming
 
 Since SwayOSD uses GTK, its appearance can be changed. Initially scss is used, which GTK does not support, so we need to use plain css. 

--- a/src/argtypes.rs
+++ b/src/argtypes.rs
@@ -9,6 +9,7 @@ pub enum ArgTypes {
 	MaxVolume = isize::MIN + 2,
 	CustomIcon = isize::MIN + 3,
 	Player = isize::MIN + 4,
+	MonitorName = isize::MIN + 5,
 	// Other
 	None = 0,
 	CapsLock = 1,
@@ -50,6 +51,7 @@ impl fmt::Display for ArgTypes {
 			ArgTypes::CustomIcon => "CUSTOM-ICON",
 			ArgTypes::Playerctl => "PLAYERCTL",
 			ArgTypes::Player => "PLAYER",
+			ArgTypes::MonitorName => "MONITOR-NAME",
 		};
 		return write!(f, "{}", string);
 	}
@@ -79,6 +81,7 @@ impl str::FromStr for ArgTypes {
 			"CUSTOM-ICON" => ArgTypes::CustomIcon,
 			"PLAYERCTL" => ArgTypes::Playerctl,
 			"PLAYER" => ArgTypes::Player,
+			"MONITOR-NAME" => ArgTypes::MonitorName,
 			other_type => return Err(other_type.to_owned()),
 		};
 		Ok(result)

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -192,6 +192,15 @@ fn main() -> Result<(), glib::Error> {
 	);
 
 	app.add_main_option(
+		"monitor",
+		glib::Char::from(0),
+		OptionFlags::NONE,
+		OptionArg::String,
+		"Which monitor to display osd on",
+		Some("Monitor identifier (e.g., HDMI-A-1, DP-1)"),
+	);
+
+	app.add_main_option(
 		"custom-message",
 		glib::Char::from(0),
 		OptionFlags::NONE,

--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -118,6 +118,16 @@ pub(crate) fn handle_application_args(
 				};
 				(ArgTypes::DeviceName, Some(value))
 			}
+			"monitor" => {
+				let value = match child.value().str() {
+					Some(v) => v.to_string(),
+					None => {
+						eprintln!("--monitor found but no name given");
+						return (HandleLocalStatus::FAILURE, actions);
+					}
+				};
+				(ArgTypes::MonitorName, Some(value))
+			}
 			"custom-message" => {
 				let value = match child.value().str() {
 					Some(v) => v.to_string(),

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -22,6 +22,7 @@ lazy_static! {
 	static ref MAX_VOLUME: Mutex<u8> = Mutex::new(PRIV_MAX_VOLUME_DEFAULT);
 	pub static ref DEVICE_NAME_DEFAULT: &'static str = "default";
 	static ref DEVICE_NAME: Mutex<Option<String>> = Mutex::new(None);
+	static ref MONITOR_NAME: Mutex<Option<String>> = Mutex::new(None);
 	pub static ref ICON_NAME_DEFAULT: &'static str = "text-x-generic";
 	static ref ICON_NAME: Mutex<Option<String>> = Mutex::new(None);
 	static ref PLAYER_NAME: Mutex<PlayerctlDeviceRaw> = Mutex::new(PlayerctlDeviceRaw::None);
@@ -89,6 +90,20 @@ pub fn set_device_name(name: String) {
 pub fn reset_device_name() {
 	let mut global_name = DEVICE_NAME.lock().unwrap();
 	*global_name = None;
+}
+
+pub fn get_monitor_name() -> Option<String> {
+	(*MONITOR_NAME.lock().unwrap()).clone()
+}
+
+pub fn set_monitor_name(name: String) {
+	let mut monitor_name = MONITOR_NAME.lock().unwrap();
+	*monitor_name = Some(name);
+}
+
+pub fn reset_monitor_name() {
+	let mut monitor_name = MONITOR_NAME.lock().unwrap();
+	*monitor_name = None;
 }
 
 pub fn get_icon_name() -> Option<String> {


### PR DESCRIPTION
Hello, this pr addresses https://github.com/ErikReider/SwayOSD/issues/80

I use three monitors, and I find it a bit irritating to show the osd on every one of them when I change my volume.

So, this introduces --monitor [identifier] to display the osd only on the specified monitor.
For me at least it's specifically useful to only show it on my active monitor, which would be possible on Hyprland like this:
`swayosd-client --monitor "$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .name')" --output-volume -2` 
or on sway like this:
`swayosd-client --monitor "$(swaymsg -t get_outputs | jq -r '.[] | select(.focused == true).name')" --output-volume raise`, 
for which I've added a note on the readme, since I think that's quite useful

If the parameter isn't specified, it continues to show the osd on all monitors, just like before