### PR TITLE
fix panic when metadata url does not exists

### DIFF
--- a/src/mpris-backend/mod.rs
+++ b/src/mpris-backend/mod.rs
@@ -60,12 +60,12 @@ impl Playerctl {
 		})
 	}
 	pub fn run(&mut self) -> Result<(), Box<dyn Error>> {
-		let mut metadata = Err("some errro");
+		let mut metadata = None;
 		let mut icon = Err("some errro");
 		match &self.player {
 			PlayerctlDevice::Some(player) => {
 				icon = Ok(self.run_single(player)?);
-				metadata = self.get_metadata(player).or_else(|_| Err(""));
+				metadata = self.get_metadata(player);
 			}
 			PlayerctlDevice::All(players) => {
 				for player in players {
@@ -75,19 +75,15 @@ impl Playerctl {
 							icon = Ok(icon_new);
 						}
 					};
-					if let Err(_) = metadata {
-						metadata = self.get_metadata(player).or_else(|_| Err(""));
+					if metadata.is_none() {
+						metadata = self.get_metadata(player);
 					}
 				}
 			}
 		};
 
 		self.icon = Some(icon.unwrap_or("").to_string());
-		let label = if let Ok(metadata) = metadata {
-			Some(self.fmt_string(metadata))
-		} else {
-			None
-		};
+		let label = metadata.map(|metadata| self.fmt_string(metadata));
 		self.label = label;
 		Ok(())
 	}
@@ -135,29 +131,29 @@ impl Playerctl {
 		};
 		Ok(out)
 	}
-	fn get_metadata(&self, player: &Player) -> Result<Metadata, mpris::DBusError> {
+	fn get_metadata(&self, player: &Player) -> Option<Metadata> {
 		match self.action {
 			Next | Prev => {
 				if let Ok(track_list) = player.get_track_list() {
 					if let Some(track) = track_list.get(0) {
-						return player.get_track_metadata(track);
+						return player.get_track_metadata(track).ok();
 					}
 				}
-				let metadata = player.get_metadata()?;
-				let name1 = metadata.url().unwrap();
+				let metadata = player.get_metadata().ok()?;
+				let name1 = metadata.url()?;
 				let mut counter = 0;
 				while counter < 20 {
 					sleep(Duration::from_millis(5));
 					counter += 1;
-					let metadata = player.get_metadata()?;
-					let name2 = metadata.url().unwrap();
+					let metadata = player.get_metadata().ok()?;
+					let name2 = metadata.url()?;
 					if name1 != name2 {
-						return Ok(metadata);
+						return Some(metadata);
 					}
 				}
-				Ok(metadata)
+				Some(metadata)
 			}
-			_ => player.get_metadata(),
+			_ => player.get_metadata().ok(),
 		}
 	}
 	fn fmt_string(&self, metadata: mpris::Metadata) -> String {

--- a/src/server/application.rs
+++ b/src/server/application.rs
@@ -454,9 +454,9 @@ impl SwayOSDApplication {
 				if let Ok(mut player) = Playerctl::new(action, server_config) {
 					match player.run() {
 						Ok(_) => {
-							let (icon, label) = (player.icon.unwrap(), player.label.unwrap());
+							let (icon, label) = (player.icon.unwrap_or_default(), &player.label);
 							for window in Self::choose_windows(osd_app) {
-								window.changed_player(&icon, &label)
+								window.changed_player(&icon, label.as_deref())
 							}
 							reset_monitor_name();
 						}

--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -166,11 +166,11 @@ impl SwayosdWindow {
 		self.run_timeout();
 	}
 
-	pub fn changed_player(&self, icon: &str, label: &str) {
+	pub fn changed_player(&self, icon: &str, label: Option<&str>) {
 		self.clear_osd();
 
-		let icon = self.build_icon_widget(&icon);
-		let label = self.build_text_widget(Some(&label));
+		let icon = self.build_icon_widget(icon);
+		let label = self.build_text_widget(label);
 
 		self.container.append(&icon);
 		self.container.append(&label);


### PR DESCRIPTION
This fixes a few unwrap which panics when metadata URL does not exists. Since the DBusError is never used (and now the function might have error that's unrelated to it (missing metadata URL), I've converted it into option.

Some example of the previous panics
```bash
$ swayosd-server
Connecting to the SwayOSD LibInput Backend

(swayosd-server:1907201): Gdk-WARNING **: 14:53:52.094: vkAcquireNextImageKHR(): A swapchain no longer matches the surface properties exactly, but can still be used to present to the surface successfully. (VK_SUBOPTIMAL_KHR) (1000001003)

(swayosd-server:1907201): Gdk-WARNING **: 14:53:52.117: vkAcquireNextImageKHR(): A swapchain no longer matches the surface properties exactly, but can still be used to present to the surface successfully. (VK_SUBOPTIMAL_KHR) (1000001003)

thread 'main' panicked at src/server/../mpris-backend/mod.rs:147:44:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Channel Send error: sending into a closed channel



$ swayosd-server
Connecting to the SwayOSD LibInput Backend

(swayosd-server:1980878): Gdk-WARNING **: 14:56:50.055: vkAcquireNextImageKHR(): A swapchain no longer matches the surface properties exactly, but can still be used to present to the surface successfully. (VK_SUBOPTIMAL_KHR) (1000001003)

(swayosd-server:1980878): Gdk-WARNING **: 14:56:50.079: vkAcquireNextImageKHR(): A swapchain no longer matches the surface properties exactly, but can still be used to present to the surface successfully. (VK_SUBOPTIMAL_KHR) (1000001003)
thread 'main' panicked at src/server/../mpris-backend/mod.rs:153:48:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace



$ swayosd-server
Connecting to the SwayOSD LibInput Backend

(swayosd-server:2175565): Gdk-WARNING **: 15:04:44.956: vkAcquireNextImageKHR(): A swapchain no longer matches the surface properties exactly, but can still be used to present to the surface successfully. (VK_SUBOPTIMAL_KHR) (1000001003)

(swayosd-server:2175565): Gdk-WARNING **: 15:04:44.980: vkAcquireNextImageKHR(): A swapchain no longer matches the surface properties exactly, but can still be used to present to the surface successfully. (VK_SUBOPTIMAL_KHR) (1000001003)
^[[57435u^[[57435uthread 'main' panicked at src/server/application.rs:457:85:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```