### PR TITLE
Update default configs

### DIFF
--- a/data/config/backend.toml
+++ b/data/config/backend.toml
@@ -1,1 +1,3 @@
 [input]
+## completely ignore the caps lock key (useful if it's rebound to something else like escape)
+# ignore_caps_lock_key = false

--- a/data/config/config.toml
+++ b/data/config/config.toml
@@ -1,4 +1,4 @@
-[client]
+[server]
 ## style file for the OSD
 # style = /etc/xdg/swayosd/style.css
 
@@ -16,4 +16,4 @@
 ## Available values:
 ## artist, albumArtist, title, album, trackNumber, discNumber, autoRating
 
-[server]
+[client]


### PR DESCRIPTION
This makes two changes to the default configs:

**config.toml:**
Switched the client and server sections. These were backward compared to the actual implementation, with all properties being under the client section, and the server section being empty.

https://github.com/ErikReider/SwayOSD/blob/bbff4efddb95275b8f3898efbd1be98bbef4c7df/src/config/user.rs#L8-L20

Closes #145.

**backend.toml:**
Added `ignore_caps_lock_key` with its default value, and a comment inspired by the comment [where it's used in code](https://github.com/ErikReider/SwayOSD/blob/bbff4efddb95275b8f3898efbd1be98bbef4c7df/src/input-backend/main.rs#L125-L126).