### PR TITLE
Fix --custom-progress to register 0 as a valid input

### DIFF
--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -219,7 +219,7 @@ fn main() -> Result<(), glib::Error> {
 		"custom-progress",
 		glib::Char::from(0),
 		OptionFlags::NONE,
-		OptionArg::Double,
+		OptionArg::String,
 		"Progress to display (0.0 <-> 1.0)",
 		Some("Progress from 0.0 to 1.0"),
 	);

--- a/src/global_utils.rs
+++ b/src/global_utils.rs
@@ -161,10 +161,10 @@ pub(crate) fn handle_application_args(
 				(ArgTypes::CustomIcon, Some(value))
 			}
 			"custom-progress" => {
-				let value = child.value().get::<f64>();
-				match value {
-					Some(value) => (ArgTypes::CustomProgress, Some(value.to_string())),
-					None => {
+				let value = child.value().str().unwrap_or("").trim();
+				match value.parse::<f64>() {
+					Ok(_) => (ArgTypes::CustomProgress, Some(value.to_string())),
+					Err(_) => {
 						eprintln!(
 							"{} is not a number between 0.0 and 1.0!",
 							child.value().print(true)


### PR DESCRIPTION
`--custom-progress` seems to ignore argument when value is `0` or `0.0`. Running `swayosd-client --custom-progress=0` would exit with error message `No args provided...`.

I suspect it has something to do with how GLib handles `0` as an argument value when the argument type is `Double`.
Instead used `String` and validated the value inside `handle_application_args`, consistent with how the other numeric arguments are parsed.

New to Rust, sorry if I overlooked something obvious.
