### PR TITLE
feat: add duration argument to swayosd-server

### DIFF
--- a/data/config/config.toml
+++ b/data/config/config.toml
@@ -24,4 +24,10 @@ min_brightness = 5
 # (automatically or through a firmware-handled hotkey being pressed)
 keyboard_backlight = true
 
+# OSD display duration in milliseconds (200-60000)
+# Possible values: 200 - 60000
+# Default value: 1000
+# Note: This is the server wide default which can be overridden by every individual client call.
+duration = 1000
+
 [client]

--- a/src/args.rs
+++ b/src/args.rs
@@ -16,6 +16,10 @@ pub struct ArgsServer {
 	/// OSD margin from top edge (0.5 would be screen center). Default is 0.85
 	#[arg(long, value_name = "from 0.0 to 1.0")]
 	pub top_margin: Option<String>,
+
+	/// OSD display duration in milliseconds (200-60000)
+	#[arg(long, short = 'd', value_name = "200-60000", default_value = "1000", value_parser = clap::value_parser!(u64).range(200..=60000))]
+	pub duration: u64,
 }
 
 #[derive(Parser)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -99,6 +99,10 @@ pub struct ArgsClient {
 	#[arg(long, value_name = "(+)number")]
 	pub min_brightness: Option<String>,
 
+	/// OSD display duration in milliseconds (200-60000)
+	#[arg(long, short = 'd', value_name = "200-60000", value_parser = clap::value_parser!(u64).range(200..=60000))]
+	pub duration: Option<u64>,
+
 	/// Shows Playerctl osd and runs the playerctl command
 	#[arg(long, value_name = "play-pause|play|pause|stop|next|prev|shuffle")]
 	pub playerctl: Option<String>,

--- a/src/argtypes.rs
+++ b/src/argtypes.rs
@@ -12,6 +12,7 @@ pub enum ArgTypes {
 	MonitorName = (i32::MIN + 5) as isize,
 	CustomProgressText = (i32::MIN + 6) as isize,
 	MinBrightness = (i32::MIN + 7) as isize,
+	Duration = (i32::MIN + 8) as isize,
 	// Other
 	CapsLock = 1,
 	SinkVolumeRaise = 2,
@@ -60,6 +61,7 @@ impl fmt::Display for ArgTypes {
 			ArgTypes::CustomProgressText => "CUSTOM-PROGRESS-TEXT",
 			ArgTypes::MinBrightness => "MIN-BRIGHTNESS",
 			ArgTypes::KbdBacklight => "KBD-BACKLIGHT",
+			ArgTypes::Duration => "DURATION",
 		};
 		write!(f, "{}", string)
 	}
@@ -95,6 +97,7 @@ impl str::FromStr for ArgTypes {
 			"CUSTOM-PROGRESS-TEXT" => ArgTypes::CustomProgressText,
 			"MIN-BRIGHTNESS" => ArgTypes::MinBrightness,
 			"KBD-BACKLIGHT" => ArgTypes::KbdBacklight,
+			"DURATION" => ArgTypes::Duration,
 			other_type => return Err(other_type.to_owned()),
 		};
 		Ok(result)

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -99,6 +99,10 @@ fn parse_args(args: &ArgsClient, proxy: &ServerProxyBlocking<'_>) {
 			_ => eprintln!("{} is not a number between 0 and {}!", value, 100),
 		}
 	}
+	// Duration
+	if let Some(value) = args.duration.to_owned() {
+		actions.push((ArgTypes::Duration, Some(value.to_string())));
+	}
 
 	//
 	// Main options

--- a/src/server/application.rs
+++ b/src/server/application.rs
@@ -32,6 +32,7 @@ pub struct SwayOSDApplication {
 	windows: Rc<RefCell<Vec<SwayosdWindow>>>,
 	activated: Rc<RefCell<bool>>,
 	_hold: Rc<gio::ApplicationHoldGuard>,
+	duration: u64,
 }
 
 impl SwayOSDApplication {
@@ -60,6 +61,7 @@ impl SwayOSDApplication {
 			windows: Rc::new(RefCell::new(Vec::new())),
 			activated: Rc::new(RefCell::new(false)),
 			_hold: hold,
+			duration: args.duration,
 		};
 
 		// Apply Server Config
@@ -359,7 +361,7 @@ impl SwayOSDApplication {
 				.item(position + i)
 				.and_then(|obj| obj.downcast::<gdk::Monitor>().ok())
 			{
-				let window = SwayosdWindow::new(&self.app, &monitor);
+				let window = SwayosdWindow::new(&self.app, &monitor, self.duration);
 				windows.push(window);
 			}
 		}

--- a/src/server/application.rs
+++ b/src/server/application.rs
@@ -643,6 +643,11 @@ impl SwayOSDApplication {
 			(ArgTypes::CustomIcon, icon) => {
 				set_icon_name(icon.unwrap_or(ICON_NAME_DEFAULT.to_string()))
 			}
+			(ArgTypes::Duration, duration) => {
+				if let Some(duration) = duration.and_then(|d| d.parse().ok()) {
+					set_duration_override(duration);
+				}
+			}
 			(arg_type, data) => {
 				eprintln!(
 					"Failed to parse command... Type: {:?}, Data: {:?}",

--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -29,6 +29,7 @@ pub struct SwayosdWindow {
 	pub monitor: gdk::Monitor,
 	container: gtk::Box,
 	timeout_id: Rc<RefCell<Option<glib::SourceId>>>,
+	duration: u64,
 }
 
 // TODO: Use custom widget
@@ -36,7 +37,7 @@ pub struct SwayosdWindow {
 //   - Always center the centered widget (both left and right sides are the same width)
 impl SwayosdWindow {
 	/// Create a new window and assign it to the given application.
-	pub fn new(app: &gtk::Application, monitor: &gdk::Monitor) -> Self {
+	pub fn new(app: &gtk::Application, monitor: &gdk::Monitor, duration: u64) -> Self {
 		let window = gtk::ApplicationWindow::new(app);
 		window.set_widget_name("osd");
 		window.add_css_class("osd");
@@ -104,6 +105,7 @@ impl SwayosdWindow {
 			container,
 			monitor: monitor.clone(),
 			timeout_id: Rc::new(RefCell::new(None)),
+			duration,
 		}
 	}
 
@@ -338,7 +340,7 @@ impl SwayosdWindow {
 		}
 		let s = self.clone();
 		self.timeout_id.replace(Some(glib::timeout_add_local_once(
-			Duration::from_millis(1000),
+			Duration::from_millis(s.duration),
 			move || {
 				s.window.hide();
 				s.timeout_id.replace(None);

--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -13,8 +13,8 @@ use crate::widgets::segmented_progress_widget::SegmentedProgressWidget;
 use crate::{
 	brightness_backend::BrightnessBackend,
 	utils::{
-		get_max_volume, get_show_percentage, get_top_margin, volume_to_f64, KeysLocks,
-		VolumeDeviceType,
+		get_duration_override, get_max_volume, get_show_percentage, get_top_margin,
+		reset_duration_override, volume_to_f64, KeysLocks, VolumeDeviceType,
 	},
 };
 
@@ -338,9 +338,11 @@ impl SwayosdWindow {
 		if let Some(timeout_id) = self.timeout_id.take() {
 			timeout_id.remove()
 		}
+		let duration = get_duration_override().unwrap_or(self.duration);
+		reset_duration_override();
 		let s = self.clone();
 		self.timeout_id.replace(Some(glib::timeout_add_local_once(
-			Duration::from_millis(s.duration),
+			Duration::from_millis(duration),
 			move || {
 				s.window.hide();
 				s.timeout_id.replace(None);

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -31,6 +31,7 @@ lazy_static! {
 	static ref PLAYER_NAME: Mutex<PlayerctlDeviceRaw> = Mutex::new(PlayerctlDeviceRaw::None);
 	pub static ref TOP_MARGIN_DEFAULT: f32 = 0.85_f32;
 	static ref TOP_MARGIN: Mutex<f32> = Mutex::new(*TOP_MARGIN_DEFAULT);
+	static ref DURATION_OVERRIDE: Mutex<Option<u64>> = Mutex::new(None);
 	pub static ref SHOW_PERCENTAGE: Mutex<bool> = Mutex::new(false);
 }
 
@@ -94,6 +95,20 @@ pub fn get_top_margin() -> f32 {
 pub fn set_top_margin(margin: f32) {
 	let mut margin_mut = TOP_MARGIN.lock().unwrap();
 	*margin_mut = margin;
+}
+
+pub fn get_duration_override() -> Option<u64> {
+	*DURATION_OVERRIDE.lock().unwrap()
+}
+
+pub fn set_duration_override(duration: u64) {
+	let mut duration_mut = DURATION_OVERRIDE.lock().unwrap();
+	*duration_mut = Some(duration);
+}
+
+pub fn reset_duration_override() {
+	let mut duration_mut = DURATION_OVERRIDE.lock().unwrap();
+	*duration_mut = None;
 }
 
 pub fn get_show_percentage() -> bool {


### PR DESCRIPTION
This adds the --duration (or -d in short) parameter to swayosd-server.
It makes it possible to define how long OSD messages are visible on the screen.
min: 200 milliseconds
max: 60000 milliseconds
default: 1000 milliseconds

It was also requested here: https://github.com/ErikReider/SwayOSD/issues/118