### PR TITLE
feat: add DDC/CI based brightness backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
  "gloo-timers",
  "kv-log-macro",
  "log",
- "memchr",
+ "memchr 2.7.6",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -293,6 +293,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cairo-rs"
@@ -421,6 +427,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +519,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "ddc"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba69f2c53e320fc4abad17cb02bbbf04d1a36f18e9907f347589ec5991b3c6c5"
+dependencies = [
+ "mccs 0.1.3",
+]
+
+[[package]]
+name = "ddc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1363c64a5107a51aa7a4198f7a0a61e3ae2347737ef26360dbd7f6025d6ee4f0"
+dependencies = [
+ "mccs 0.2.0",
+]
+
+[[package]]
+name = "ddc-hi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6747b17c926a2aa34739b30f1a6cc726e3a7baf0e2f69a4c03a95cf5de94de"
+dependencies = [
+ "anyhow",
+ "ddc 0.2.2",
+ "ddc-i2c",
+ "ddc-macos",
+ "ddc-winapi",
+ "edid",
+ "log",
+ "mccs 0.1.3",
+ "mccs-caps",
+ "mccs-db",
+ "nvapi",
+]
+
+[[package]]
+name = "ddc-i2c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ef18fac9fd5c11d0c7b85a80887b01f7361b49edb2b4627243928b90ce2691b"
+dependencies = [
+ "ddc 0.2.2",
+ "i2c",
+ "i2c-linux",
+ "resize-slice",
+]
+
+[[package]]
+name = "ddc-macos"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28aca22e30b33daf41a5d269a19b00588adf5242ed5525d3818195de17a534dc"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "core-graphics",
+ "ddc 0.2.2",
+ "io-kit-sys",
+ "mach2",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ddc-winapi"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b65693556bdf54c77e0c82db4951686e4f030e7eb1c643d1bc781de2a4bce35"
+dependencies = [
+ "ddc 0.2.2",
+ "widestring",
+ "winapi",
+]
+
+[[package]]
 name = "derive_is_enum_variant"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +602,21 @@ dependencies = [
  "heck 0.3.3",
  "quote 0.3.15",
  "syn 0.11.11",
+]
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "edid"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ce75530893d834dcfe3bb67ce0e7dec489484e7cb4423ca31618af4bab24fe"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -620,6 +756,33 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.41",
+ "syn 2.0.107",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "from_variants"
@@ -865,7 +1028,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "memchr",
+ "memchr 2.7.6",
  "smallvec",
 ]
 
@@ -1089,6 +1252,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "i2c"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60c7b7bdd7b3a985fdcf94a0d7d98e7a47fde8b7f22fb55ce1a91cc104a2ce9a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "i2c-linux"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0268a871aaa071221d6c2875ebedcf64710e59b0d87c68c8faf5e98b87dd2a4"
+dependencies = [
+ "bitflags 1.3.2",
+ "i2c",
+ "i2c-linux-sys",
+ "resize-slice",
+ "udev 0.2.0",
+]
+
+[[package]]
+name = "i2c-linux-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cd060ed0016621d3da4ed3a23b0158084de90d1f3a8e59f3d391aacd3bbcf8"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,7 +1310,7 @@ dependencies = [
  "input-sys",
  "libc",
  "log",
- "udev",
+ "udev 0.9.3",
 ]
 
 [[package]]
@@ -1122,6 +1318,16 @@ name = "input-sys"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd4f5b4d1c00331c5245163aacfe5f20be75b564c7112d45893d4ae038119eb0"
+
+[[package]]
+name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
 
 [[package]]
 name = "io-lifetimes"
@@ -1233,6 +1439,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1463,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mccs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6090d6b3ded42fed158b660a6b9cdaa1924f3eef6c6598e82a9ca9b70a1988cd"
+dependencies = [
+ "void",
+]
+
+[[package]]
+name = "mccs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a63ab5297c9a7d5f8298a076b5f858c3c51ce84bf2f57a302d1d67ff9323360"
+
+[[package]]
+name = "mccs-caps"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb961d01a3bb07969cfa276be2ab88c31d0fefa77a872696832732d6e9ec094"
+dependencies = [
+ "mccs 0.1.3",
+ "nom",
+]
+
+[[package]]
+name = "mccs-db"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cdaa8fe19a1a1918becc1b8cbbbdc1058bc71411dff4de0a6ec6b5269f49d38"
+dependencies = [
+ "mccs 0.1.3",
+ "nom",
+ "serde",
+ "serde_derive",
+ "serde_yaml",
+]
+
+[[package]]
+name = "memchr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1295,6 +1563,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
+dependencies = [
+ "memchr 1.0.2",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1589,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "nvapi"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c63de8cd8362e2c38d1a48dea6ae68e6293a8d8d22a52180d0f8dcc779b3158"
+dependencies = [
+ "i2c",
+ "log",
+ "nvapi-sys",
+ "void",
+]
+
+[[package]]
+name = "nvapi-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b29e9a9393c69ee856bfcf5f76ed1ef32d2c0dd6f58558fd43334278fc1e7ea7"
+dependencies = [
+ "bitflags 1.3.2",
+ "winapi",
 ]
 
 [[package]]
@@ -1458,6 +1757,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "resize-slice"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3cb2f74a9891e76958b9e0ccd269a25b466c3ae3bb3efd71db157248308c4a"
+dependencies = [
+ "uninitialized",
+]
+
+[[package]]
 name = "runtime-format"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1881,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8099d3df28273c99a1728190c7a9f19d444c941044f64adf986bee7ec53051"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "swayosd"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1655,6 +1975,8 @@ dependencies = [
  "blight",
  "cascade",
  "clap",
+ "ddc 0.3.0",
+ "ddc-hi",
  "evdev-rs",
  "gtk4",
  "gtk4-layer-shell",
@@ -1930,6 +2252,16 @@ dependencies = [
 
 [[package]]
 name = "udev"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47504d1a49b2ea1b133e7ddd1d9f0a83cf03feb9b440c2c470d06db4589cf301"
+dependencies = [
+ "libc",
+ "libudev-sys",
+]
+
+[[package]]
+name = "udev"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4e37e9ea4401fc841ff54b9ddfc9be1079b1e89434c1a6a865dd68980f7e9f"
@@ -1970,6 +2302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
+name = "uninitialized"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c1aa4511c38276c548406f0b1f5f8b793f000cfb51e18f278a102abd057e81"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,6 +2335,12 @@ name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasip2"
@@ -2088,6 +2432,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -2271,7 +2621,7 @@ version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
- "memchr",
+ "memchr 2.7.6",
 ]
 
 [[package]]
@@ -2285,6 +2635,15 @@ name = "xml-rs"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zbus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,5 @@ mpris = "2.0.1"
 runtime-format = "0.1.3"
 strfmt = "0.2.4"
 clap = { version = "4.5.53", features = ["derive"] }
+ddc = "0.3.0"
+ddc-hi = "0.4.1"

--- a/src/brightness_backend/ddcci.rs
+++ b/src/brightness_backend/ddcci.rs
@@ -1,0 +1,165 @@
+use crate::global_utils::div_round_u32;
+
+use super::{BrightnessBackend, BrightnessBackendConstructor};
+
+use ddc_hi::{Ddc, Display};
+use anyhow::bail;
+use std::{cell::RefCell, rc::Rc};
+use thiserror::Error;
+
+/// VCP feature code to get and set the brightness of the monitor via DDC/CI
+const VCP_BRIGHTNESS_FEATURE: u8 = 0x10;
+
+#[derive(Error, Debug)]
+#[error("Requested device '{device_name}' does not exist ")]
+pub struct DeviceDoesntExistError {
+	device_name: String,
+}
+
+struct DdcDevice {
+	display: Rc<RefCell<Display>>,
+	current: u32,
+	max: u32,
+}
+
+#[allow(unused)]
+impl DdcDevice {
+	fn try_new(device_name: Option<String>) -> anyhow::Result<Self> {
+		let mut displays = Display::enumerate();
+
+		// Try to find the exact display if it was specified
+		if let Some(ref name) = device_name {
+			if let Some(n) = displays
+				.iter()
+				.position(|d| d.info.model_name.as_deref() == Some(name))
+			{
+				// Test if the display supports the Brightness feature
+				let mut display = displays.swap_remove(n);
+				if let Ok(vcp_response) = display.handle.get_vcp_feature(VCP_BRIGHTNESS_FEATURE) {
+					return Ok(Self {
+						display: Rc::new(RefCell::new(display)),
+						current: vcp_response.value() as u32,
+						max: vcp_response.maximum() as u32
+					});
+				} else {
+					// The device was found, but doesn't support brightness control via DDC/CI
+					// NOTE: perhaps a fallback to the first useable display is better instead?
+					bail!(DeviceDoesntExistError {
+						device_name: device_name.unwrap_or("Device name unknown".to_string())
+					})
+				}
+			} else {
+				// The device couldn't be found
+				// NOTE: perhaps a fallback to the first useable display is better instead?
+				bail!(DeviceDoesntExistError {
+					device_name: device_name.unwrap_or("Device name unknown".to_string())
+				})
+			}
+		} else {
+			// Search for the first display responsive to the Brightness feature
+			for i in 0..displays.len() {
+				let vcp_response = displays.get_mut(i)
+					.unwrap().handle
+					.get_vcp_feature(VCP_BRIGHTNESS_FEATURE)?;
+
+				let display = displays.swap_remove(i);
+				return Ok(Self {
+					display: Rc::new(RefCell::new(display)),
+					current: vcp_response.value() as u32,
+					max: vcp_response.maximum() as u32
+				});
+			}
+
+			// There are no displays that can be used, at all
+			bail!(DeviceDoesntExistError {
+				device_name: "N/A".to_string()
+			})
+		}
+	}
+
+	fn get_current(&mut self) -> u32 {
+		self.current
+	}
+
+	fn get_max(&mut self) -> u32 {
+		self.max
+	}
+
+	fn get_percent(&mut self) -> u32 {
+		let cur = self.get_current();
+		let max = self.get_max();
+		div_round_u32(cur * 100, max)
+	}
+
+	fn set_raw(&mut self, val: u32) -> anyhow::Result<()> {
+		let max = self.get_max();
+		let clamped_val = val.clamp(0, max);
+
+		// Try to update the Brightness
+		self.display.borrow_mut()
+			.handle
+			.set_vcp_feature(VCP_BRIGHTNESS_FEATURE, clamped_val as u16)
+			.expect("DdcDevice failed to set brightness");
+
+		self.current = clamped_val;
+		Ok(())
+	}
+
+	fn set_percent(&mut self, val: u32) -> anyhow::Result<()> {
+		// The monitor should accept everything in percentages
+		// but if it doesn't, scale the percentage to the expected value
+		let clamped_val = val.clamp(0, 100);
+		let max = self.get_max();
+		let raw_val = div_round_u32(clamped_val * max, 100);
+
+		self.set_raw(raw_val)
+	}
+}
+
+
+#[allow(unused)]
+pub(super) struct Ddcci {
+	device: DdcDevice
+}
+
+impl BrightnessBackendConstructor for Ddcci {
+	fn try_new(device_name: Option<String>) -> anyhow::Result<Self> {
+		Ok(Self {
+			device: DdcDevice::try_new(device_name)?,
+		})
+	}
+}
+
+impl BrightnessBackend for Ddcci {
+	fn get_current(&mut self) -> u32 {
+		self.device.get_current()
+	}
+
+	fn get_max(&mut self) -> u32 {
+		self.device.get_max()
+	}
+
+	fn lower(&mut self, by: u32, min: u32) -> anyhow::Result<()> {
+		let max = self.device.get_max();
+		let cur = self.device.get_current();
+		let step = div_round_u32(by * max, 100);
+		let new_val = cur.saturating_sub(step);
+		let min_raw = div_round_u32(min * max, 100);
+		self.device.set_raw(new_val.max(min_raw))
+	}
+
+	fn raise(&mut self, by: u32, min: u32) -> anyhow::Result<()> {
+		let max = self.device.get_max();
+		let curr = self.device.get_current();
+		let step = div_round_u32(by * max, 100);
+		let new_val = (curr + step).min(max);
+		let min_raw = div_round_u32(min * max, 100);
+		self.device.set_raw(new_val.max(min_raw))
+	}
+
+	fn set(&mut self, val: u32, min: u32) -> anyhow::Result<()> {
+		let max = self.device.get_max();
+		let raw_val = div_round_u32(val.max(min) * max, 100);
+		self.device.set_raw(raw_val)
+	}
+}

--- a/src/brightness_backend/mod.rs
+++ b/src/brightness_backend/mod.rs
@@ -1,8 +1,10 @@
-use self::{blight::Blight, brightnessctl::BrightnessCtl};
+use self::{blight::Blight, brightnessctl::BrightnessCtl, ddcci::Ddcci};
 
 mod blight;
 
 mod brightnessctl;
+
+mod ddcci;
 
 pub type BrightnessBackendResult = anyhow::Result<Box<dyn BrightnessBackend>>;
 
@@ -31,8 +33,13 @@ pub trait BrightnessBackend {
 #[allow(dead_code)]
 pub fn get_preferred_backend(device_name: Option<String>) -> BrightnessBackendResult {
 	println!("Trying BrightnessCtl Backend...");
-	BrightnessCtl::try_new_boxed(device_name.clone()).or_else(|_| {
-		println!("...Command failed! Falling back to Blight");
-		Blight::try_new_boxed(device_name)
-	})
+	BrightnessCtl::try_new_boxed(device_name.clone())
+		.or_else(|_| {
+			println!("Trying Blight Backend...");
+			Blight::try_new_boxed(device_name.clone())
+		})
+		.or_else(|_| {
+			println!("Trying DDC/CI Backend...");
+			Ddcci::try_new_boxed(device_name)
+		})
 }

--- a/src/mpris-backend/mod.rs
+++ b/src/mpris-backend/mod.rs
@@ -149,14 +149,15 @@ impl Playerctl {
 				let metadata = player.get_metadata().ok()?;
 				let name1 = metadata.url()?;
 				let mut counter = 0;
-				while counter < 20 {
-					sleep(Duration::from_millis(5));
-					counter += 1;
+				while counter < 1000 {
+					// 1000 * 5ms = 5s
 					let metadata = player.get_metadata().ok()?;
 					let name2 = metadata.url()?;
 					if name1 != name2 {
 						return Some(metadata);
 					}
+					sleep(Duration::from_millis(5));
+					counter += 1;
 				}
 				Some(metadata)
 			}


### PR DESCRIPTION
While blight and brightnessctl are more than enough to support devices which expose a sysfs backlight interface, most external monitors connected to discrete or internal GPUs can't be accessed through those backends.
Although ddcci-driver-linux exists, modern (post 6.7) kernels aren't supported properly or don't work outright. In those cases it would make sense to fall back to a DDC/CI based interface, to provide some level of control regardless, without the need for explicit scripting.

This adds the [ddc](https://crates.io/crates/ddc-hi) and [ddc-hi](https://crates.io/crates/ddc-hi) crates to interface with monitors using DDC/CI and a new `Ddcci` backlight backend which uses those crates.