### PR TITLE
Add WirePlumber audio backend support

### DIFF
--- a/src/audio_backend/mod.rs
+++ b/src/audio_backend/mod.rs
@@ -1,0 +1,49 @@
+use self::pulsectl::PulseAudio;
+use self::wireplumber::WirePlumber;
+
+mod pulsectl;
+mod wireplumber;
+
+pub type AudioBackendResult = anyhow::Result<Box<dyn AudioBackend>>;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AudioDeviceType {
+	Sink,   // Output
+	Source, // Input
+}
+
+#[derive(Clone, Debug)]
+pub struct AudioDeviceInfo {
+	pub volume: f64, // 0.0 - 100.0+
+	pub mute: bool,
+}
+
+pub trait AudioBackendConstructor: AudioBackend + Sized + 'static {
+	fn try_new(device_type: AudioDeviceType, device_name: Option<String>) -> anyhow::Result<Self>;
+
+	fn try_new_boxed(device_type: AudioDeviceType, device_name: Option<String>) -> AudioBackendResult {
+		let backend = Self::try_new(device_type, device_name);
+		match backend {
+			Ok(backend) => Ok(Box::new(backend)),
+			Err(e) => Err(e),
+		}
+	}
+}
+
+pub trait AudioBackend {
+	fn get_device_info(&mut self) -> anyhow::Result<AudioDeviceInfo>;
+	fn set_volume(&mut self, delta: f64, max_volume: u8) -> anyhow::Result<AudioDeviceInfo>;
+	fn toggle_mute(&mut self) -> anyhow::Result<AudioDeviceInfo>;
+}
+
+pub fn get_preferred_backend(
+	device_type: AudioDeviceType,
+	device_name: Option<String>,
+) -> AudioBackendResult {
+	// Try WirePlumber first (native PipeWire)
+	println!("Trying WirePlumber Backend...");
+	WirePlumber::try_new_boxed(device_type, device_name.clone()).or_else(|e| {
+		println!("...WirePlumber failed: {e}! Falling back to PulseAudio");
+		PulseAudio::try_new_boxed(device_type, device_name)
+	})
+}

--- a/src/audio_backend/pulsectl.rs
+++ b/src/audio_backend/pulsectl.rs
@@ -1,0 +1,118 @@
+use pulse::volume::Volume;
+use pulsectl::controllers::{
+	types::DeviceInfo, DeviceControl, SinkController, SourceController,
+};
+
+use super::{AudioBackend, AudioBackendConstructor, AudioDeviceInfo, AudioDeviceType};
+
+pub enum PulseController {
+	Sink(SinkController),
+	Source(SourceController),
+}
+
+pub struct PulseAudio {
+	controller: PulseController,
+	device_name: Option<String>,
+}
+
+impl AudioBackendConstructor for PulseAudio {
+	fn try_new(device_type: AudioDeviceType, device_name: Option<String>) -> anyhow::Result<Self> {
+		let controller = match device_type {
+			AudioDeviceType::Sink => PulseController::Sink(SinkController::create()?),
+			AudioDeviceType::Source => PulseController::Source(SourceController::create()?),
+		};
+
+		Ok(Self {
+			controller,
+			device_name,
+		})
+	}
+}
+
+impl PulseAudio {
+	fn volume_to_f64(volume: &Volume) -> f64 {
+		let tmp_vol = f64::from(volume.0 - Volume::MUTED.0);
+		(100.0 * tmp_vol / f64::from(Volume::NORMAL.0 - Volume::MUTED.0)).round()
+	}
+
+	fn volume_from_f64(volume: f64) -> Volume {
+		let tmp = f64::from(Volume::NORMAL.0 - Volume::MUTED.0) * volume / 100_f64;
+		Volume((tmp + f64::from(Volume::MUTED.0)) as u32)
+	}
+
+	fn get_controller_and_device(
+		&mut self,
+	) -> anyhow::Result<(&mut dyn DeviceControl<DeviceInfo>, DeviceInfo)> {
+		let (controller, default_name): (&mut dyn DeviceControl<DeviceInfo>, Option<String>) =
+			match &mut self.controller {
+				PulseController::Sink(ctrl) => {
+					let server_info = ctrl.get_server_info()?;
+					(ctrl, server_info.default_sink_name)
+				}
+				PulseController::Source(ctrl) => {
+					let server_info = ctrl.get_server_info()?;
+					(ctrl, server_info.default_source_name)
+				}
+			};
+
+		// Get the device
+		let device = if let Some(ref name) = self.device_name {
+			controller.get_device_by_name(name)?
+		} else {
+			// Workaround the upstream issues in pulsectl-rs where getting the default source device
+			// doesn't work...
+			controller.get_device_by_name(&default_name.unwrap_or_default())?
+		};
+
+		Ok((controller, device))
+	}
+}
+
+impl AudioBackend for PulseAudio {
+	fn get_device_info(&mut self) -> anyhow::Result<AudioDeviceInfo> {
+		let (_, device) = self.get_controller_and_device()?;
+
+		Ok(AudioDeviceInfo {
+			volume: Self::volume_to_f64(&device.volume.avg()),
+			mute: device.mute,
+		})
+	}
+
+	fn set_volume(&mut self, delta: f64, max_volume: u8) -> anyhow::Result<AudioDeviceInfo> {
+		let (controller, device) = self.get_controller_and_device()?;
+
+		let max_vol = Self::volume_from_f64(max_volume as f64);
+		let delta_vol = Self::volume_from_f64(delta);
+
+		if delta >= 0.0 {
+			if let Some(volume) = device.volume.clone().inc_clamp(delta_vol, max_vol) {
+				controller.set_device_volume_by_index(device.index, volume);
+			}
+		} else {
+			// For negative delta, decrease volume
+			if let Some(volume) = device.volume.clone().decrease(Self::volume_from_f64(-delta)) {
+				controller.set_device_volume_by_index(device.index, volume);
+			}
+		}
+
+		// Get updated device info
+		let updated = controller.get_device_by_index(device.index)?;
+		Ok(AudioDeviceInfo {
+			volume: Self::volume_to_f64(&updated.volume.avg()),
+			mute: updated.mute,
+		})
+	}
+
+	fn toggle_mute(&mut self) -> anyhow::Result<AudioDeviceInfo> {
+		let (controller, device) = self.get_controller_and_device()?;
+
+		controller.set_device_mute_by_index(device.index, !device.mute);
+
+		// Get updated device info
+		let updated = controller.get_device_by_index(device.index)?;
+		Ok(AudioDeviceInfo {
+			volume: Self::volume_to_f64(&updated.volume.avg()),
+			mute: updated.mute,
+		})
+	}
+}

--- a/src/audio_backend/wireplumber.rs
+++ b/src/audio_backend/wireplumber.rs
@@ -1,0 +1,138 @@
+use std::process::Command;
+
+use anyhow::{bail, Context};
+
+use super::{AudioBackend, AudioBackendConstructor, AudioDeviceInfo, AudioDeviceType};
+
+const DEFAULT_SINK: &str = "@DEFAULT_AUDIO_SINK@";
+const DEFAULT_SOURCE: &str = "@DEFAULT_AUDIO_SOURCE@";
+
+pub struct WirePlumber {
+	device_type: AudioDeviceType,
+	device_name: Option<String>,
+}
+
+impl AudioBackendConstructor for WirePlumber {
+	fn try_new(device_type: AudioDeviceType, device_name: Option<String>) -> anyhow::Result<Self> {
+		let backend = Self {
+			device_type,
+			device_name,
+		};
+
+		// Check if wpctl is available and WirePlumber is running
+		let output = backend
+			.wpctl_command()
+			.arg("status")
+			.output()
+			.context("Failed to run wpctl status")?;
+
+		if !output.status.success() {
+			bail!("wpctl status failed - WirePlumber may not be running");
+		}
+
+		Ok(backend)
+	}
+}
+
+impl WirePlumber {
+	fn wpctl_command(&self) -> Command {
+		Command::new("wpctl")
+	}
+
+	fn get_device_target(&self) -> String {
+		if let Some(ref name) = self.device_name {
+			name.clone()
+		} else {
+			match self.device_type {
+				AudioDeviceType::Sink => DEFAULT_SINK.to_string(),
+				AudioDeviceType::Source => DEFAULT_SOURCE.to_string(),
+			}
+		}
+	}
+
+	fn parse_volume_output(output: &str) -> anyhow::Result<f64> {
+		// Output format: "Volume: 0.45" or "Volume: 0.45 [MUTED]"
+		for line in output.lines() {
+			let line = line.trim();
+			if let Some(vol_str) = line.strip_prefix("Volume:") {
+				let vol_str = vol_str.trim();
+				// Take only the numeric part (before any brackets or spaces)
+				let vol_str = vol_str.split_whitespace().next().unwrap_or("0");
+				let volume: f64 = vol_str.parse().context("Failed to parse volume")?;
+				// Convert from 0.0-1.0 to 0-100
+				return Ok(volume * 100.0);
+			}
+		}
+		bail!("Could not parse volume from wpctl output: {}", output)
+	}
+
+	fn parse_mute_status(output: &str) -> bool {
+		// Check if output contains [MUTED]
+		output.contains("[MUTED]")
+	}
+}
+
+impl AudioBackend for WirePlumber {
+	fn get_device_info(&mut self) -> anyhow::Result<AudioDeviceInfo> {
+		let target = self.get_device_target();
+
+		let output = self
+			.wpctl_command()
+			.args(["get-volume", &target])
+			.output()
+			.context("Failed to run wpctl get-volume")?;
+
+		if !output.status.success() {
+			let stderr = String::from_utf8_lossy(&output.stderr);
+			bail!("wpctl get-volume failed: {}", stderr);
+		}
+
+		let stdout = String::from_utf8_lossy(&output.stdout);
+		let volume = Self::parse_volume_output(&stdout)?;
+		let mute = Self::parse_mute_status(&stdout);
+
+		Ok(AudioDeviceInfo { volume, mute })
+	}
+
+	fn set_volume(&mut self, delta: f64, max_volume: u8) -> anyhow::Result<AudioDeviceInfo> {
+		let target = self.get_device_target();
+		let current = self.get_device_info()?;
+		let max_vol = max_volume as f64;
+
+		// Calculate new volume with clamping
+		let new_volume = (current.volume + delta).clamp(0.0, max_vol);
+
+		// wpctl uses 0.0-1.0 range
+		let vol_arg = format!("{:.3}", new_volume / 100.0);
+
+		let output = self
+			.wpctl_command()
+			.args(["set-volume", &target, &vol_arg])
+			.output()
+			.context("Failed to run wpctl set-volume")?;
+
+		if !output.status.success() {
+			let stderr = String::from_utf8_lossy(&output.stderr);
+			bail!("wpctl set-volume failed: {}", stderr);
+		}
+
+		self.get_device_info()
+	}
+
+	fn toggle_mute(&mut self) -> anyhow::Result<AudioDeviceInfo> {
+		let target = self.get_device_target();
+
+		let output = self
+			.wpctl_command()
+			.args(["set-mute", &target, "toggle"])
+			.output()
+			.context("Failed to run wpctl set-mute")?;
+
+		if !output.status.success() {
+			let stderr = String::from_utf8_lossy(&output.stderr);
+			bail!("wpctl set-mute toggle failed: {}", stderr);
+		}
+
+		self.get_device_info()
+	}
+}

--- a/src/server/application.rs
+++ b/src/server/application.rs
@@ -18,7 +18,6 @@ use gtk::{
 	prelude::*,
 	Application,
 };
-use pulsectl::controllers::{SinkController, SourceController};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -397,12 +396,12 @@ impl SwayOSDApplication {
 	) -> Result<(), Box<dyn std::error::Error>> {
 		match (arg_type, value) {
 			(ArgTypes::SinkVolumeRaise, step) => {
-				let mut device_type = VolumeDeviceType::Sink(SinkController::create()?);
+				let device_type = VolumeDeviceType::Sink;
 				if let Some(device) =
-					change_device_volume(&mut device_type, VolumeChangeType::Raise, step)
+					change_device_volume(device_type, VolumeChangeType::Raise, step)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&device, &device_type);
+						window.changed_volume(&device, device_type);
 					}
 				}
 				reset_max_volume();
@@ -410,12 +409,12 @@ impl SwayOSDApplication {
 				reset_monitor_name();
 			}
 			(ArgTypes::SinkVolumeLower, step) => {
-				let mut device_type = VolumeDeviceType::Sink(SinkController::create()?);
+				let device_type = VolumeDeviceType::Sink;
 				if let Some(device) =
-					change_device_volume(&mut device_type, VolumeChangeType::Lower, step)
+					change_device_volume(device_type, VolumeChangeType::Lower, step)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&device, &device_type);
+						window.changed_volume(&device, device_type);
 					}
 				}
 				reset_max_volume();
@@ -423,12 +422,12 @@ impl SwayOSDApplication {
 				reset_monitor_name();
 			}
 			(ArgTypes::SinkVolumeMuteToggle, _) => {
-				let mut device_type = VolumeDeviceType::Sink(SinkController::create()?);
+				let device_type = VolumeDeviceType::Sink;
 				if let Some(device) =
-					change_device_volume(&mut device_type, VolumeChangeType::MuteToggle, None)
+					change_device_volume(device_type, VolumeChangeType::MuteToggle, None)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&device, &device_type);
+						window.changed_volume(&device, device_type);
 					}
 				}
 				reset_max_volume();
@@ -436,12 +435,12 @@ impl SwayOSDApplication {
 				reset_monitor_name();
 			}
 			(ArgTypes::SourceVolumeRaise, step) => {
-				let mut device_type = VolumeDeviceType::Source(SourceController::create()?);
+				let device_type = VolumeDeviceType::Source;
 				if let Some(device) =
-					change_device_volume(&mut device_type, VolumeChangeType::Raise, step)
+					change_device_volume(device_type, VolumeChangeType::Raise, step)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&device, &device_type);
+						window.changed_volume(&device, device_type);
 					}
 				}
 				reset_max_volume();
@@ -449,12 +448,12 @@ impl SwayOSDApplication {
 				reset_monitor_name();
 			}
 			(ArgTypes::SourceVolumeLower, step) => {
-				let mut device_type = VolumeDeviceType::Source(SourceController::create()?);
+				let device_type = VolumeDeviceType::Source;
 				if let Some(device) =
-					change_device_volume(&mut device_type, VolumeChangeType::Lower, step)
+					change_device_volume(device_type, VolumeChangeType::Lower, step)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&device, &device_type);
+						window.changed_volume(&device, device_type);
 					}
 				}
 				reset_max_volume();
@@ -462,12 +461,12 @@ impl SwayOSDApplication {
 				reset_monitor_name();
 			}
 			(ArgTypes::SourceVolumeMuteToggle, _) => {
-				let mut device_type = VolumeDeviceType::Source(SourceController::create()?);
+				let device_type = VolumeDeviceType::Source;
 				if let Some(device) =
-					change_device_volume(&mut device_type, VolumeChangeType::MuteToggle, None)
+					change_device_volume(device_type, VolumeChangeType::MuteToggle, None)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&device, &device_type);
+						window.changed_volume(&device, device_type);
 					}
 				}
 				reset_max_volume();

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -17,6 +17,9 @@ mod global_utils;
 #[path = "../brightness_backend/mod.rs"]
 mod brightness_backend;
 
+#[path = "../audio_backend/mod.rs"]
+mod audio_backend;
+
 #[path = "../mpris-backend/mod.rs"]
 mod playerctl;
 

--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -7,13 +7,13 @@ use gtk::{
 	glib::{self, clone},
 	prelude::*,
 };
-use pulsectl::controllers::types::DeviceInfo;
 
+use crate::audio_backend::AudioDeviceInfo;
 use crate::widgets::segmented_progress_widget::SegmentedProgressWidget;
 use crate::{
 	brightness_backend::BrightnessBackend,
 	utils::{
-		get_max_volume, get_show_percentage, get_top_margin, volume_to_f64, KeysLocks,
+		get_max_volume, get_show_percentage, get_top_margin, KeysLocks,
 		VolumeDeviceType,
 	},
 };
@@ -111,13 +111,13 @@ impl SwayosdWindow {
 		self.window.close();
 	}
 
-	pub fn changed_volume(&self, device: &DeviceInfo, device_type: &VolumeDeviceType) {
+	pub fn changed_volume(&self, device: &AudioDeviceInfo, device_type: VolumeDeviceType) {
 		self.clear_osd();
 
-		let volume = volume_to_f64(&device.volume.avg());
+		let volume = device.volume;
 		let icon_prefix = match device_type {
-			VolumeDeviceType::Sink(_) => "sink",
-			VolumeDeviceType::Source(_) => "source",
+			VolumeDeviceType::Sink => "sink",
+			VolumeDeviceType::Source => "source",
 		};
 		let icon_state = &match (device.mute, volume) {
 			(true, _) => "muted",
@@ -126,8 +126,8 @@ impl SwayosdWindow {
 			(false, x) if x > 33.0 && x <= 66.0 => "medium",
 			(false, x) if x > 66.0 && x <= 100.0 => "high",
 			(false, x) if x > 100.0 => match device_type {
-				VolumeDeviceType::Sink(_) => "high",
-				VolumeDeviceType::Source(_) => "overamplified",
+				VolumeDeviceType::Sink => "high",
+				VolumeDeviceType::Source => "overamplified",
 			},
 			(_, _) => "high",
 		};


### PR DESCRIPTION
Add audio backend abstraction layer that supports both WirePlumber (native PipeWire) and PulseAudio backends. WirePlumber is tried first, falling back to PulseAudio if unavailable. This allows using SwayOSD without the pipewire-pulse compatibility layer.

----

The commit and everything _above_ this line was all entirely done by AI. In fact, it's a one-shot (well, one prompt). Quite impressive really!

I did go over the code and to me it looks oke. But i'm not a Rust developer and don't look at it with rust eyes. I like that it went for an AudioBackend interface/trait logic with just 2 implementations of it.

But yes, it's fully AI. You can accept it. Or use as inspiration for a better patch. All fine by me, i'm merely sharing the work so that others who might want to use it can.

It would fix #219 