### PR TITLE
Fix quotes in config.toml style path

### DIFF
--- a/data/config/config.toml
+++ b/data/config/config.toml
@@ -1,6 +1,6 @@
 [server]
 ## style file for the OSD
-# style = /etc/xdg/swayosd/style.css
+# style = "/etc/xdg/swayosd/style.css"
 
 ## on which height to show the OSD
 # top_margin = 0.85


### PR DESCRIPTION
- Any path name must be in quotes, otherwise the toml parsing will fail with error and `swayosd-server` will panic.