### PR TITLE
Fix integer division in kbd backlight progress bar calculation

### DIFF
--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -204,7 +204,7 @@ impl SwayosdWindow {
 			let progress = self.build_segmented_progress_widget(value, max);
 			self.container.append(&progress);
 		} else {
-			let progress = self.build_progress_widget((value / max) as f64);
+			let progress = self.build_progress_widget(value as f64 / max as f64);
 			self.container.append(&progress);
 		}
 


### PR DESCRIPTION
Fix integer division in kbd backlight progress bar calculation

Problem

The keyboard backlight OSD progress bar was always showing either 0% or 100% (except when the backlight was at maximum), because value / max performed integer division before casting to f64. For example, with a value of 50 and a max of 255, 50 / 255 evaluates to 0 in integer arithmetic, causing the progress bar to show empty.

Fix

Cast both operands to f64 before dividing: value as f64 / max as f64.