### PR TITLE
Fix default input muting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,10 +1436,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulsectl-rs"
-version = "0.3.2"
+name = "pulsectl2-rs"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a988bceed1981b2c5fc4a3da0e4e073fdaff8e6bd022b089f54bc573dc3cfc"
+checksum = "822ad2dfde5f4dd41b23d058ae47be82c39dca05847fe46129a7d1fb59ccdd18"
 dependencies = [
  "libpulse-binding",
 ]
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "swayosd"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1667,7 +1667,7 @@ dependencies = [
  "mpris",
  "nix",
  "playerctld",
- "pulsectl-rs",
+ "pulsectl2-rs",
  "runtime-format",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ gtk-layer-shell = { package = "gtk4-layer-shell", version = "0.6.3" }
 shrinkwraprs = "0.3.0"
 cascade = "1.0.1"
 pulse = { version = "2.30.1", package = "libpulse-binding" }
-pulsectl-rs = "0.3.2"
+pulsectl2-rs = "0.3.3"
 substring = "1.4.5"
 lazy_static = "1.5.0"
 zbus = "5"

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -260,24 +260,11 @@ pub fn change_device_volume(
 	change_type: VolumeChangeType,
 	step: Option<String>,
 ) -> Option<DeviceInfo> {
-	// Get the sink/source controller + default device name
-	let (controller, default_name): (&mut dyn DeviceControl<DeviceInfo>, Option<String>) =
-		match device_type {
-			VolumeDeviceType::Sink(controller) => match controller.get_server_info() {
-				Ok(server_info) => (controller, server_info.default_sink_name),
-				Err(e) => {
-					eprintln!("Error getting the Sink server info: {}", e);
-					return None;
-				}
-			},
-			VolumeDeviceType::Source(controller) => match controller.get_server_info() {
-				Ok(server_info) => (controller, server_info.default_source_name),
-				Err(e) => {
-					eprintln!("Error getting the Source server info: {}", e);
-					return None;
-				}
-			},
-		};
+	// Get the sink/source controller
+	let controller: &mut dyn DeviceControl<DeviceInfo> = match device_type {
+		VolumeDeviceType::Sink(controller) => controller,
+		VolumeDeviceType::Source(controller) => controller,
+	};
 
 	// Get the device
 	let device: DeviceInfo = if let Some(name) = get_device_name()
@@ -285,9 +272,7 @@ pub fn change_device_volume(
 	{
 		device
 	} else {
-		// Workaround the upstream issues in pulsectl-rs where getting the default source device
-		// doesn't work...
-		match controller.get_device_by_name(&default_name.unwrap_or("".to_string())) {
+		match controller.get_default_device() {
 			Ok(device) => device,
 			Err(e) => {
 				eprintln!("Error getting the default device: {}", e);


### PR DESCRIPTION
Fixes https://github.com/ErikReider/SwayOSD/issues/225

Previous fix attempt was insufficient because `set_device_mute_by_index` was also broken, not just `get_default_device`.
Tested by running `swayosd-client --input-volume mute-toggle` couple times, which didn't work for me previously.

`pulsectl2-rs` is my fork of the previous crate. The fix was already proposed years ago, but the author has archived the repo. I intend to improve it a bit, but it's not a priority for me. Anyway, feedback is welcome.