### PR TITLE
Replace pulsectl-rs with local pulse module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,15 +1436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulsectl-rs"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a988bceed1981b2c5fc4a3da0e4e073fdaff8e6bd022b089f54bc573dc3cfc"
-dependencies = [
- "libpulse-binding",
-]
-
-[[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,17 +1630,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "substring"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "swayosd"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1667,13 +1649,11 @@ dependencies = [
  "mpris",
  "nix",
  "playerctld",
- "pulsectl-rs",
  "runtime-format",
  "serde",
  "serde_derive",
  "shrinkwraprs",
  "strfmt",
- "substring",
  "thiserror 2.0.17",
  "toml 0.8.23",
  "zbus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,6 @@ gtk-layer-shell = { package = "gtk4-layer-shell", version = "0.6.3" }
 shrinkwraprs = "0.3.0"
 cascade = "1.0.1"
 pulse = { version = "2.30.1", package = "libpulse-binding" }
-pulsectl-rs = "0.3.2"
-substring = "1.4.5"
 lazy_static = "1.5.0"
 zbus = "5"
 # Backend Dependencies

--- a/src/server/application.rs
+++ b/src/server/application.rs
@@ -18,7 +18,7 @@ use gtk::{
 	prelude::*,
 	Application,
 };
-use pulsectl::controllers::{SinkController, SourceController};
+use crate::pulse::{DeviceKind, VolumeController};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -397,12 +397,12 @@ impl SwayOSDApplication {
 	) -> Result<(), Box<dyn std::error::Error>> {
 		match (arg_type, value) {
 			(ArgTypes::SinkVolumeRaise, step) => {
-				let mut device_type = VolumeDeviceType::Sink(SinkController::create()?);
+				let mut ctrl = VolumeController::create(DeviceKind::Sink)?;
 				if let Some(device) =
-					change_device_volume(&mut device_type, VolumeChangeType::Raise, step)
+					change_device_volume(&mut ctrl, VolumeChangeType::Raise, step)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&device, &device_type);
+						window.changed_volume(&device, ctrl.kind());
 					}
 				}
 				reset_max_volume();
@@ -410,12 +410,12 @@ impl SwayOSDApplication {
 				reset_monitor_name();
 			}
 			(ArgTypes::SinkVolumeLower, step) => {
-				let mut device_type = VolumeDeviceType::Sink(SinkController::create()?);
+				let mut ctrl = VolumeController::create(DeviceKind::Sink)?;
 				if let Some(device) =
-					change_device_volume(&mut device_type, VolumeChangeType::Lower, step)
+					change_device_volume(&mut ctrl, VolumeChangeType::Lower, step)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&device, &device_type);
+						window.changed_volume(&device, ctrl.kind());
 					}
 				}
 				reset_max_volume();
@@ -423,12 +423,12 @@ impl SwayOSDApplication {
 				reset_monitor_name();
 			}
 			(ArgTypes::SinkVolumeMuteToggle, _) => {
-				let mut device_type = VolumeDeviceType::Sink(SinkController::create()?);
+				let mut ctrl = VolumeController::create(DeviceKind::Sink)?;
 				if let Some(device) =
-					change_device_volume(&mut device_type, VolumeChangeType::MuteToggle, None)
+					change_device_volume(&mut ctrl, VolumeChangeType::MuteToggle, None)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&device, &device_type);
+						window.changed_volume(&device, ctrl.kind());
 					}
 				}
 				reset_max_volume();
@@ -436,12 +436,12 @@ impl SwayOSDApplication {
 				reset_monitor_name();
 			}
 			(ArgTypes::SourceVolumeRaise, step) => {
-				let mut device_type = VolumeDeviceType::Source(SourceController::create()?);
+				let mut ctrl = VolumeController::create(DeviceKind::Source)?;
 				if let Some(device) =
-					change_device_volume(&mut device_type, VolumeChangeType::Raise, step)
+					change_device_volume(&mut ctrl, VolumeChangeType::Raise, step)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&device, &device_type);
+						window.changed_volume(&device, ctrl.kind());
 					}
 				}
 				reset_max_volume();
@@ -449,12 +449,12 @@ impl SwayOSDApplication {
 				reset_monitor_name();
 			}
 			(ArgTypes::SourceVolumeLower, step) => {
-				let mut device_type = VolumeDeviceType::Source(SourceController::create()?);
+				let mut ctrl = VolumeController::create(DeviceKind::Source)?;
 				if let Some(device) =
-					change_device_volume(&mut device_type, VolumeChangeType::Lower, step)
+					change_device_volume(&mut ctrl, VolumeChangeType::Lower, step)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&device, &device_type);
+						window.changed_volume(&device, ctrl.kind());
 					}
 				}
 				reset_max_volume();
@@ -462,12 +462,12 @@ impl SwayOSDApplication {
 				reset_monitor_name();
 			}
 			(ArgTypes::SourceVolumeMuteToggle, _) => {
-				let mut device_type = VolumeDeviceType::Source(SourceController::create()?);
+				let mut ctrl = VolumeController::create(DeviceKind::Source)?;
 				if let Some(device) =
-					change_device_volume(&mut device_type, VolumeChangeType::MuteToggle, None)
+					change_device_volume(&mut ctrl, VolumeChangeType::MuteToggle, None)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&device, &device_type);
+						window.changed_volume(&device, ctrl.kind());
 					}
 				}
 				reset_max_volume();

--- a/src/server/application.rs
+++ b/src/server/application.rs
@@ -33,6 +33,8 @@ pub struct SwayOSDApplication {
 	activated: Rc<RefCell<bool>>,
 	_hold: Rc<gio::ApplicationHoldGuard>,
 	duration: u64,
+
+	volume_ctrl: Rc<RefCell<Option<VolumeController>>>,
 }
 
 impl SwayOSDApplication {
@@ -56,12 +58,16 @@ impl SwayOSDApplication {
 			Some("<from 0.0 to 1.0>"),
 		);
 
+		let volume_ctrl = VolumeController::create().ok();
+
 		let osd_app = SwayOSDApplication {
 			app: app.clone(),
 			windows: Rc::new(RefCell::new(Vec::new())),
 			activated: Rc::new(RefCell::new(false)),
 			_hold: hold,
 			duration: args.duration,
+
+			volume_ctrl: Rc::new(RefCell::new(volume_ctrl)),
 		};
 
 		// Apply Server Config
@@ -406,11 +412,12 @@ impl SwayOSDApplication {
 		match (arg_type, value) {
 			(ArgTypes::SinkVolumeRaise, step) => {
 				let duration = self.get_duration();
-				let mut ctrl = VolumeController::create(DeviceKind::Sink)?;
-				if let Some(device) = change_device_volume(&mut ctrl, VolumeChangeType::Raise, step)
+				let ctrl = &self.volume_ctrl;
+				if let Some(device) =
+					change_device_volume(ctrl, DeviceKind::Sink, VolumeChangeType::Raise, step)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&duration, &device, ctrl.kind());
+						window.changed_volume(&duration, &device);
 					}
 				}
 				reset_max_volume();
@@ -419,11 +426,12 @@ impl SwayOSDApplication {
 			}
 			(ArgTypes::SinkVolumeLower, step) => {
 				let duration = self.get_duration();
-				let mut ctrl = VolumeController::create(DeviceKind::Sink)?;
-				if let Some(device) = change_device_volume(&mut ctrl, VolumeChangeType::Lower, step)
+				let ctrl = &self.volume_ctrl;
+				if let Some(device) =
+					change_device_volume(ctrl, DeviceKind::Sink, VolumeChangeType::Lower, step)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&duration, &device, ctrl.kind());
+						window.changed_volume(&duration, &device);
 					}
 				}
 				reset_max_volume();
@@ -432,12 +440,12 @@ impl SwayOSDApplication {
 			}
 			(ArgTypes::SinkVolumeMuteToggle, _) => {
 				let duration = self.get_duration();
-				let mut ctrl = VolumeController::create(DeviceKind::Sink)?;
+				let ctrl = &self.volume_ctrl;
 				if let Some(device) =
-					change_device_volume(&mut ctrl, VolumeChangeType::MuteToggle, None)
+					change_device_volume(ctrl, DeviceKind::Sink, VolumeChangeType::MuteToggle, None)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&duration, &device, ctrl.kind());
+						window.changed_volume(&duration, &device);
 					}
 				}
 				reset_max_volume();
@@ -446,11 +454,12 @@ impl SwayOSDApplication {
 			}
 			(ArgTypes::SourceVolumeRaise, step) => {
 				let duration = self.get_duration();
-				let mut ctrl = VolumeController::create(DeviceKind::Source)?;
-				if let Some(device) = change_device_volume(&mut ctrl, VolumeChangeType::Raise, step)
+				let ctrl = &self.volume_ctrl;
+				if let Some(device) =
+					change_device_volume(ctrl, DeviceKind::Source, VolumeChangeType::Raise, step)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&duration, &device, ctrl.kind());
+						window.changed_volume(&duration, &device);
 					}
 				}
 				reset_max_volume();
@@ -459,11 +468,12 @@ impl SwayOSDApplication {
 			}
 			(ArgTypes::SourceVolumeLower, step) => {
 				let duration = self.get_duration();
-				let mut ctrl = VolumeController::create(DeviceKind::Source)?;
-				if let Some(device) = change_device_volume(&mut ctrl, VolumeChangeType::Lower, step)
+				let ctrl = &self.volume_ctrl;
+				if let Some(device) =
+					change_device_volume(ctrl, DeviceKind::Source, VolumeChangeType::Lower, step)
 				{
 					for window in self.choose_windows() {
-						window.changed_volume(&duration, &device, ctrl.kind());
+						window.changed_volume(&duration, &device);
 					}
 				}
 				reset_max_volume();
@@ -472,12 +482,15 @@ impl SwayOSDApplication {
 			}
 			(ArgTypes::SourceVolumeMuteToggle, _) => {
 				let duration = self.get_duration();
-				let mut ctrl = VolumeController::create(DeviceKind::Source)?;
-				if let Some(device) =
-					change_device_volume(&mut ctrl, VolumeChangeType::MuteToggle, None)
-				{
+				let ctrl = &self.volume_ctrl;
+				if let Some(device) = change_device_volume(
+					ctrl,
+					DeviceKind::Source,
+					VolumeChangeType::MuteToggle,
+					None,
+				) {
 					for window in self.choose_windows() {
-						window.changed_volume(&duration, &device, ctrl.kind());
+						window.changed_volume(&duration, &device);
 					}
 				}
 				reset_max_volume();

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -1,6 +1,7 @@
 mod application;
 mod login1;
 mod osd_window;
+mod pulse;
 mod upower;
 mod utils;
 mod widgets;

--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -108,11 +108,11 @@ impl SwayosdWindow {
 		self.window.close();
 	}
 
-	pub fn changed_volume(&self, duration: &Option<u64>, device: &DeviceInfo, kind: DeviceKind) {
+	pub fn changed_volume(&self, duration: &Option<u64>, device: &DeviceInfo) {
 		self.clear_osd();
 
 		let volume = volume_to_f64(&device.volume.avg());
-		let icon_prefix = match kind {
+		let icon_prefix = match device.kind {
 			DeviceKind::Sink => "sink",
 			DeviceKind::Source => "source",
 		};
@@ -122,7 +122,7 @@ impl SwayosdWindow {
 			(false, x) if x > 0.0 && x <= 33.0 => "low",
 			(false, x) if x > 33.0 && x <= 66.0 => "medium",
 			(false, x) if x > 66.0 && x <= 100.0 => "high",
-			(false, x) if x > 100.0 => match kind {
+			(false, x) if x > 100.0 => match device.kind {
 				DeviceKind::Sink => "high",
 				DeviceKind::Source => "overamplified",
 			},

--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -2,20 +2,17 @@ use std::rc::Rc;
 use std::time::Duration;
 use std::{cell::RefCell, ops::Deref};
 
+use crate::pulse::{DeviceInfo, DeviceKind};
 use gtk::{
 	gdk,
 	glib::{self, clone},
 	prelude::*,
 };
-use pulsectl::controllers::types::DeviceInfo;
 
 use crate::widgets::segmented_progress_widget::SegmentedProgressWidget;
 use crate::{
 	brightness_backend::BrightnessBackend,
-	utils::{
-		get_max_volume, get_show_percentage, get_top_margin, volume_to_f64, KeysLocks,
-		VolumeDeviceType,
-	},
+	utils::{get_max_volume, get_show_percentage, get_top_margin, volume_to_f64, KeysLocks},
 };
 
 use gtk_layer_shell::LayerShell;
@@ -111,13 +108,13 @@ impl SwayosdWindow {
 		self.window.close();
 	}
 
-	pub fn changed_volume(&self, device: &DeviceInfo, device_type: &VolumeDeviceType) {
+	pub fn changed_volume(&self, device: &DeviceInfo, kind: DeviceKind) {
 		self.clear_osd();
 
 		let volume = volume_to_f64(&device.volume.avg());
-		let icon_prefix = match device_type {
-			VolumeDeviceType::Sink(_) => "sink",
-			VolumeDeviceType::Source(_) => "source",
+		let icon_prefix = match kind {
+			DeviceKind::Sink => "sink",
+			DeviceKind::Source => "source",
 		};
 		let icon_state = &match (device.mute, volume) {
 			(true, _) => "muted",
@@ -125,9 +122,9 @@ impl SwayosdWindow {
 			(false, x) if x > 0.0 && x <= 33.0 => "low",
 			(false, x) if x > 33.0 && x <= 66.0 => "medium",
 			(false, x) if x > 66.0 && x <= 100.0 => "high",
-			(false, x) if x > 100.0 => match device_type {
-				VolumeDeviceType::Sink(_) => "high",
-				VolumeDeviceType::Source(_) => "overamplified",
+			(false, x) if x > 100.0 => match kind {
+				DeviceKind::Sink => "high",
+				DeviceKind::Source => "overamplified",
 			},
 			(_, _) => "high",
 		};

--- a/src/server/pulse.rs
+++ b/src/server/pulse.rs
@@ -1,3 +1,4 @@
+use gtk::glib::clone;
 use pulse::{
 	callbacks::ListResult,
 	context::{introspect, Context},
@@ -42,14 +43,16 @@ impl From<pulse::error::PAErr> for PulseError {
 /// Minimal device info needed by SwayOSD.
 #[derive(Debug, Clone)]
 pub struct DeviceInfo {
+	pub kind: DeviceKind,
 	pub index: u32,
 	pub volume: ChannelVolumes,
 	pub mute: bool,
 }
 
-impl<'a> From<&'a introspect::SinkInfo<'a>> for DeviceInfo {
-	fn from(info: &'a introspect::SinkInfo<'a>) -> Self {
+impl From<&introspect::SinkInfo<'_>> for DeviceInfo {
+	fn from(info: &introspect::SinkInfo) -> Self {
 		DeviceInfo {
+			kind: DeviceKind::Sink,
 			index: info.index,
 			volume: info.volume,
 			mute: info.mute,
@@ -57,9 +60,10 @@ impl<'a> From<&'a introspect::SinkInfo<'a>> for DeviceInfo {
 	}
 }
 
-impl<'a> From<&'a introspect::SourceInfo<'a>> for DeviceInfo {
-	fn from(info: &'a introspect::SourceInfo<'a>) -> Self {
+impl From<&introspect::SourceInfo<'_>> for DeviceInfo {
+	fn from(info: &introspect::SourceInfo) -> Self {
 		DeviceInfo {
+			kind: DeviceKind::Source,
 			index: info.index,
 			volume: info.volume,
 			mute: info.mute,
@@ -68,21 +72,53 @@ impl<'a> From<&'a introspect::SourceInfo<'a>> for DeviceInfo {
 }
 
 // ---------------------------------------------------------------------------
-// Handler: PulseAudio connection wrapper
+// Callback helper: collects the first item from a PulseAudio list callback.
+//
+// libpulse-binding's SinkInfo/SourceInfo carry a lifetime parameter that
+// makes a generic function impractical (HRTB bounds don't unify). A macro
+// avoids the issue by expanding at each call site.
 // ---------------------------------------------------------------------------
 
-struct Handler {
+/// Fires a PulseAudio introspect query that yields `ListResult<&$info_ty>`,
+/// collects the first item as a `DeviceInfo`, and returns it (or an error).
+macro_rules! query_device {
+	($self:expr, $kind:expr, $introspect_method:ident ( $($arg:expr),* ), $info_ty:ty) => {{
+		let result: Rc<RefCell<Option<DeviceInfo>>> = Rc::new(RefCell::new(None));
+		let op = $self.introspect.$introspect_method(
+			$($arg,)*
+			clone!(
+				#[strong]
+				result,
+				move |list: ListResult<&$info_ty>| {
+					if let ListResult::Item(item) = list {
+						result.replace(Some(DeviceInfo::from(item)));
+					}
+				}
+			),
+		);
+		$self.wait_for_operation(op)?;
+		result
+			.take()
+			.ok_or_else(|| PulseError::GetInfo(format!("{:?} not found", $kind)))
+	}};
+}
+
+// ---------------------------------------------------------------------------
+// VolumeController: PulseAudio connection wrapper for both sinks and sources
+// ---------------------------------------------------------------------------
+
+pub struct VolumeController {
 	mainloop: Rc<RefCell<Mainloop>>,
 	context: Rc<RefCell<Context>>,
 	introspect: introspect::Introspector,
 }
 
-impl Handler {
-	fn connect(name: &str) -> Result<Self, PulseError> {
+impl VolumeController {
+	pub fn create() -> Result<Self, PulseError> {
 		let mut proplist = Proplist::new()
 			.ok_or_else(|| PulseError::Connect("Failed to create proplist".into()))?;
 		proplist
-			.set_str(pulse::proplist::properties::APPLICATION_NAME, name)
+			.set_str(pulse::proplist::properties::APPLICATION_NAME, "SwayOSD")
 			.map_err(|_| PulseError::Connect("Failed to set application name".into()))?;
 
 		let mainloop = Mainloop::new()
@@ -118,14 +154,14 @@ impl Handler {
 		}
 
 		let introspect = context.borrow_mut().introspect();
-		Ok(Handler {
+		Ok(Self {
 			mainloop,
 			context,
 			introspect,
 		})
 	}
 
-	fn wait_for_operation<G: ?Sized>(&mut self, op: Operation<G>) -> Result<(), PulseError> {
+	fn wait_for_operation<G: ?Sized>(&self, op: Operation<G>) -> Result<(), PulseError> {
 		loop {
 			match self.mainloop.borrow_mut().iterate(true) {
 				IterateResult::Err(e) => return Err(e.into()),
@@ -143,93 +179,55 @@ impl Handler {
 			}
 		}
 	}
-}
 
-impl Drop for Handler {
-	fn drop(&mut self) {
-		self.context.borrow_mut().disconnect();
-		self.mainloop.borrow_mut().quit(pulse::def::Retval(0));
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Callback helper: collects the first item from a PulseAudio list callback.
-//
-// libpulse-binding's SinkInfo/SourceInfo carry a lifetime parameter that
-// makes a generic function impractical (HRTB bounds don't unify). A macro
-// avoids the issue by expanding at each call site.
-// ---------------------------------------------------------------------------
-
-/// Fires a PulseAudio introspect query that yields `ListResult<&$info_ty>`,
-/// collects the first item as a `DeviceInfo`, and returns it (or an error).
-macro_rules! query_device {
-	($self:expr, $introspect_method:ident ( $($arg:expr),* ), $info_ty:ty) => {{
-		let result: Rc<RefCell<Option<DeviceInfo>>> = Rc::new(RefCell::new(None));
-		let result_ref = result.clone();
-		let op = $self.handler.introspect.$introspect_method(
-			$($arg,)*
-			move |list: ListResult<&$info_ty>| {
-				if let ListResult::Item(item) = list {
-					result_ref.replace(Some(DeviceInfo::from(item)));
-				}
-			},
-		);
-		$self.handler.wait_for_operation(op)?;
-		result
-			.take()
-			.ok_or_else(|| PulseError::GetInfo(format!("{:?} not found", $self.kind)))
-	}};
-}
-
-// ---------------------------------------------------------------------------
-// VolumeController: single controller for both sinks and sources
-// ---------------------------------------------------------------------------
-
-pub struct VolumeController {
-	handler: Handler,
-	kind: DeviceKind,
-}
-
-impl VolumeController {
-	pub fn create(kind: DeviceKind) -> Result<Self, PulseError> {
-		let name = match kind {
-			DeviceKind::Sink => "SwayOSD Sink",
-			DeviceKind::Source => "SwayOSD Source",
-		};
-		Ok(Self {
-			handler: Handler::connect(name)?,
-			kind,
-		})
+	pub fn get_default_device(&self, kind: DeviceKind) -> Result<DeviceInfo, PulseError> {
+		let name = self.get_default_device_name(kind)?;
+		self.get_device_by_name(kind, &name)
 	}
 
-	pub fn kind(&self) -> DeviceKind {
-		self.kind
-	}
-
-	pub fn get_default_device(&mut self) -> Result<DeviceInfo, PulseError> {
-		let name = self.get_default_device_name()?;
-		self.get_device_by_name(&name)
-	}
-
-	pub fn get_device_by_name(&mut self, name: &str) -> Result<DeviceInfo, PulseError> {
-		match self.kind {
+	pub fn get_device_by_name(
+		&self,
+		kind: DeviceKind,
+		name: &str,
+	) -> Result<DeviceInfo, PulseError> {
+		match kind {
 			DeviceKind::Sink => {
-				query_device!(self, get_sink_info_by_name(name), introspect::SinkInfo)
-			}
-			DeviceKind::Source => {
-				query_device!(self, get_source_info_by_name(name), introspect::SourceInfo)
-			}
-		}
-	}
-
-	pub fn get_device_by_index(&mut self, index: u32) -> Result<DeviceInfo, PulseError> {
-		match self.kind {
-			DeviceKind::Sink => {
-				query_device!(self, get_sink_info_by_index(index), introspect::SinkInfo)
+				query_device!(
+					self,
+					kind,
+					get_sink_info_by_name(name),
+					introspect::SinkInfo
+				)
 			}
 			DeviceKind::Source => {
 				query_device!(
 					self,
+					kind,
+					get_source_info_by_name(name),
+					introspect::SourceInfo
+				)
+			}
+		}
+	}
+
+	pub fn get_device_by_index(
+		&self,
+		kind: DeviceKind,
+		index: u32,
+	) -> Result<DeviceInfo, PulseError> {
+		match kind {
+			DeviceKind::Sink => {
+				query_device!(
+					self,
+					kind,
+					get_sink_info_by_index(index),
+					introspect::SinkInfo
+				)
+			}
+			DeviceKind::Source => {
+				query_device!(
+					self,
+					kind,
 					get_source_info_by_index(index),
 					introspect::SourceInfo
 				)
@@ -237,55 +235,56 @@ impl VolumeController {
 		}
 	}
 
-	pub fn set_volume_by_index(&mut self, index: u32, volume: &ChannelVolumes) {
-		let op = match self.kind {
+	pub fn set_volume_by_index(&mut self, kind: DeviceKind, index: u32, volume: &ChannelVolumes) {
+		let op = match kind {
 			DeviceKind::Sink => self
-				.handler
 				.introspect
 				.set_sink_volume_by_index(index, volume, None),
 			DeviceKind::Source => self
-				.handler
 				.introspect
 				.set_source_volume_by_index(index, volume, None),
 		};
-		if let Err(e) = self.handler.wait_for_operation(op) {
-			eprintln!("Failed to set {:?} volume: {}", self.kind, e);
+		if let Err(e) = self.wait_for_operation(op) {
+			eprintln!("Failed to set {:?} volume: {}", kind, e);
 		}
 	}
 
-	pub fn set_mute_by_index(&mut self, index: u32, mute: bool) {
-		let op = match self.kind {
-			DeviceKind::Sink => self
-				.handler
-				.introspect
-				.set_sink_mute_by_index(index, mute, None),
-			DeviceKind::Source => self
-				.handler
-				.introspect
-				.set_source_mute_by_index(index, mute, None),
+	pub fn set_mute_by_index(&mut self, kind: DeviceKind, index: u32, mute: bool) {
+		let op = match kind {
+			DeviceKind::Sink => self.introspect.set_sink_mute_by_index(index, mute, None),
+			DeviceKind::Source => self.introspect.set_source_mute_by_index(index, mute, None),
 		};
-		if let Err(e) = self.handler.wait_for_operation(op) {
-			eprintln!("Failed to set {:?} mute: {}", self.kind, e);
+		if let Err(e) = self.wait_for_operation(op) {
+			eprintln!("Failed to set {:?} mute: {}", kind, e);
 		}
 	}
 
-	fn get_default_device_name(&mut self) -> Result<String, PulseError> {
+	fn get_default_device_name(&self, kind: DeviceKind) -> Result<String, PulseError> {
 		let name: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
-		let name_ref = name.clone();
-		let kind = self.kind;
 
-		let op = self.handler.introspect.get_server_info(move |info| {
-			let value = match kind {
-				DeviceKind::Sink => &info.default_sink_name,
-				DeviceKind::Source => &info.default_source_name,
-			};
-			if let Some(cow) = value.as_ref() {
-				name_ref.replace(Some(cow.to_string()));
+		let op = self.introspect.get_server_info(clone!(
+			#[strong]
+			name,
+			move |info| {
+				let value = match kind {
+					DeviceKind::Sink => &info.default_sink_name,
+					DeviceKind::Source => &info.default_source_name,
+				};
+				if let Some(cow) = value.as_ref() {
+					name.replace(Some(cow.to_string()));
+				}
 			}
-		});
-		self.handler.wait_for_operation(op)?;
+		));
+		self.wait_for_operation(op)?;
 
 		name.take()
 			.ok_or_else(|| PulseError::GetInfo("No default device name".into()))
+	}
+}
+
+impl Drop for VolumeController {
+	fn drop(&mut self) {
+		self.context.borrow_mut().disconnect();
+		self.mainloop.borrow_mut().quit(pulse::def::Retval(0));
 	}
 }

--- a/src/server/pulse.rs
+++ b/src/server/pulse.rs
@@ -1,0 +1,291 @@
+use pulse::{
+	callbacks::ListResult,
+	context::{introspect, Context},
+	mainloop::standard::{IterateResult, Mainloop},
+	operation::{Operation, State},
+	proplist::Proplist,
+	volume::ChannelVolumes,
+};
+
+use std::cell::RefCell;
+use std::ops::Deref;
+use std::rc::Rc;
+
+/// Whether we're operating on an output (sink) or input (source) device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeviceKind {
+	Sink,
+	Source,
+}
+
+/// Error types for PulseAudio operations.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum PulseError {
+	#[error("PulseAudio connect error: {0}")]
+	Connect(String),
+	#[error("PulseAudio operation error: {0}")]
+	Operation(String),
+	#[error("PulseAudio get info error: {0}")]
+	GetInfo(String),
+}
+
+impl From<pulse::error::PAErr> for PulseError {
+	fn from(error: pulse::error::PAErr) -> Self {
+		Self::Operation(
+			error
+				.to_string()
+				.unwrap_or_else(|| "Unknown PA error".to_string()),
+		)
+	}
+}
+
+/// Minimal device info needed by SwayOSD.
+#[derive(Debug, Clone)]
+pub struct DeviceInfo {
+	pub index: u32,
+	pub volume: ChannelVolumes,
+	pub mute: bool,
+}
+
+impl<'a> From<&'a introspect::SinkInfo<'a>> for DeviceInfo {
+	fn from(info: &'a introspect::SinkInfo<'a>) -> Self {
+		DeviceInfo {
+			index: info.index,
+			volume: info.volume,
+			mute: info.mute,
+		}
+	}
+}
+
+impl<'a> From<&'a introspect::SourceInfo<'a>> for DeviceInfo {
+	fn from(info: &'a introspect::SourceInfo<'a>) -> Self {
+		DeviceInfo {
+			index: info.index,
+			volume: info.volume,
+			mute: info.mute,
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Handler: PulseAudio connection wrapper
+// ---------------------------------------------------------------------------
+
+struct Handler {
+	mainloop: Rc<RefCell<Mainloop>>,
+	context: Rc<RefCell<Context>>,
+	introspect: introspect::Introspector,
+}
+
+impl Handler {
+	fn connect(name: &str) -> Result<Self, PulseError> {
+		let mut proplist = Proplist::new()
+			.ok_or_else(|| PulseError::Connect("Failed to create proplist".into()))?;
+		proplist
+			.set_str(pulse::proplist::properties::APPLICATION_NAME, name)
+			.map_err(|_| PulseError::Connect("Failed to set application name".into()))?;
+
+		let mainloop = Mainloop::new()
+			.ok_or_else(|| PulseError::Connect("Failed to create mainloop".into()))?;
+		let mainloop = Rc::new(RefCell::new(mainloop));
+
+		let context = Context::new_with_proplist(mainloop.borrow().deref(), "SwayOSD", &proplist)
+			.ok_or_else(|| PulseError::Connect("Failed to create context".into()))?;
+		let context = Rc::new(RefCell::new(context));
+
+		context
+			.borrow_mut()
+			.connect(None, pulse::context::FlagSet::NOFLAGS, None)
+			.map_err(|_| PulseError::Connect("Failed to connect context".into()))?;
+
+		loop {
+			match mainloop.borrow_mut().iterate(true) {
+				IterateResult::Err(e) => return Err(e.into()),
+				IterateResult::Quit(_) => {
+					return Err(PulseError::Connect("Mainloop quit unexpectedly".into()));
+				}
+				IterateResult::Success(_) => {}
+			}
+			match context.borrow().get_state() {
+				pulse::context::State::Ready => break,
+				pulse::context::State::Failed | pulse::context::State::Terminated => {
+					return Err(PulseError::Connect(
+						"Context state failed/terminated".into(),
+					));
+				}
+				_ => {}
+			}
+		}
+
+		let introspect = context.borrow_mut().introspect();
+		Ok(Handler {
+			mainloop,
+			context,
+			introspect,
+		})
+	}
+
+	fn wait_for_operation<G: ?Sized>(&mut self, op: Operation<G>) -> Result<(), PulseError> {
+		loop {
+			match self.mainloop.borrow_mut().iterate(true) {
+				IterateResult::Err(e) => return Err(e.into()),
+				IterateResult::Quit(_) => {
+					return Err(PulseError::Operation("Mainloop quit unexpectedly".into()));
+				}
+				IterateResult::Success(_) => {}
+			}
+			match op.get_state() {
+				State::Done => return Ok(()),
+				State::Running => {}
+				State::Cancelled => {
+					return Err(PulseError::Operation("Operation cancelled".into()));
+				}
+			}
+		}
+	}
+}
+
+impl Drop for Handler {
+	fn drop(&mut self) {
+		self.context.borrow_mut().disconnect();
+		self.mainloop.borrow_mut().quit(pulse::def::Retval(0));
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Callback helper: collects the first item from a PulseAudio list callback.
+//
+// libpulse-binding's SinkInfo/SourceInfo carry a lifetime parameter that
+// makes a generic function impractical (HRTB bounds don't unify). A macro
+// avoids the issue by expanding at each call site.
+// ---------------------------------------------------------------------------
+
+/// Fires a PulseAudio introspect query that yields `ListResult<&$info_ty>`,
+/// collects the first item as a `DeviceInfo`, and returns it (or an error).
+macro_rules! query_device {
+	($self:expr, $introspect_method:ident ( $($arg:expr),* ), $info_ty:ty) => {{
+		let result: Rc<RefCell<Option<DeviceInfo>>> = Rc::new(RefCell::new(None));
+		let result_ref = result.clone();
+		let op = $self.handler.introspect.$introspect_method(
+			$($arg,)*
+			move |list: ListResult<&$info_ty>| {
+				if let ListResult::Item(item) = list {
+					result_ref.replace(Some(DeviceInfo::from(item)));
+				}
+			},
+		);
+		$self.handler.wait_for_operation(op)?;
+		result
+			.take()
+			.ok_or_else(|| PulseError::GetInfo(format!("{:?} not found", $self.kind)))
+	}};
+}
+
+// ---------------------------------------------------------------------------
+// VolumeController: single controller for both sinks and sources
+// ---------------------------------------------------------------------------
+
+pub struct VolumeController {
+	handler: Handler,
+	kind: DeviceKind,
+}
+
+impl VolumeController {
+	pub fn create(kind: DeviceKind) -> Result<Self, PulseError> {
+		let name = match kind {
+			DeviceKind::Sink => "SwayOSD Sink",
+			DeviceKind::Source => "SwayOSD Source",
+		};
+		Ok(Self {
+			handler: Handler::connect(name)?,
+			kind,
+		})
+	}
+
+	pub fn kind(&self) -> DeviceKind {
+		self.kind
+	}
+
+	pub fn get_default_device(&mut self) -> Result<DeviceInfo, PulseError> {
+		let name = self.get_default_device_name()?;
+		self.get_device_by_name(&name)
+	}
+
+	pub fn get_device_by_name(&mut self, name: &str) -> Result<DeviceInfo, PulseError> {
+		match self.kind {
+			DeviceKind::Sink => {
+				query_device!(self, get_sink_info_by_name(name), introspect::SinkInfo)
+			}
+			DeviceKind::Source => {
+				query_device!(self, get_source_info_by_name(name), introspect::SourceInfo)
+			}
+		}
+	}
+
+	pub fn get_device_by_index(&mut self, index: u32) -> Result<DeviceInfo, PulseError> {
+		match self.kind {
+			DeviceKind::Sink => {
+				query_device!(self, get_sink_info_by_index(index), introspect::SinkInfo)
+			}
+			DeviceKind::Source => {
+				query_device!(
+					self,
+					get_source_info_by_index(index),
+					introspect::SourceInfo
+				)
+			}
+		}
+	}
+
+	pub fn set_volume_by_index(&mut self, index: u32, volume: &ChannelVolumes) {
+		let op = match self.kind {
+			DeviceKind::Sink => self
+				.handler
+				.introspect
+				.set_sink_volume_by_index(index, volume, None),
+			DeviceKind::Source => self
+				.handler
+				.introspect
+				.set_source_volume_by_index(index, volume, None),
+		};
+		if let Err(e) = self.handler.wait_for_operation(op) {
+			eprintln!("Failed to set {:?} volume: {}", self.kind, e);
+		}
+	}
+
+	pub fn set_mute_by_index(&mut self, index: u32, mute: bool) {
+		let op = match self.kind {
+			DeviceKind::Sink => self
+				.handler
+				.introspect
+				.set_sink_mute_by_index(index, mute, None),
+			DeviceKind::Source => self
+				.handler
+				.introspect
+				.set_source_mute_by_index(index, mute, None),
+		};
+		if let Err(e) = self.handler.wait_for_operation(op) {
+			eprintln!("Failed to set {:?} mute: {}", self.kind, e);
+		}
+	}
+
+	fn get_default_device_name(&mut self) -> Result<String, PulseError> {
+		let name: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+		let name_ref = name.clone();
+		let kind = self.kind;
+
+		let op = self.handler.introspect.get_server_info(move |info| {
+			let value = match kind {
+				DeviceKind::Sink => &info.default_sink_name,
+				DeviceKind::Source => &info.default_source_name,
+			};
+			if let Some(cow) = value.as_ref() {
+				name_ref.replace(Some(cow.to_string()));
+			}
+		});
+		self.handler.wait_for_operation(op)?;
+
+		name.take()
+			.ok_or_else(|| PulseError::GetInfo("No default device name".into()))
+	}
+}

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -9,7 +9,8 @@ use std::{
 };
 
 use pulse::volume::Volume;
-use pulsectl::controllers::{types::DeviceInfo, DeviceControl, SinkController, SourceController};
+
+use crate::pulse::{DeviceInfo, VolumeController};
 
 use crate::brightness_backend;
 use crate::playerctl::PlayerctlDeviceRaw;
@@ -234,11 +235,6 @@ pub enum VolumeChangeType {
 	MuteToggle,
 }
 
-pub enum VolumeDeviceType {
-	Sink(SinkController),
-	Source(SourceController),
-}
-
 pub enum BrightnessChangeType {
 	Raise,
 	Lower,
@@ -256,47 +252,22 @@ fn volume_from_f64(volume: f64) -> Volume {
 }
 
 pub fn change_device_volume(
-	device_type: &mut VolumeDeviceType,
+	ctrl: &mut VolumeController,
 	change_type: VolumeChangeType,
 	step: Option<String>,
 ) -> Option<DeviceInfo> {
-	// Get the sink/source controller + default device name
-	let (controller, default_name): (&mut dyn DeviceControl<DeviceInfo>, Option<String>) =
-		match device_type {
-			VolumeDeviceType::Sink(controller) => match controller.get_server_info() {
-				Ok(server_info) => (controller, server_info.default_sink_name),
-				Err(e) => {
-					eprintln!("Error getting the Sink server info: {}", e);
-					return None;
-				}
-			},
-			VolumeDeviceType::Source(controller) => match controller.get_server_info() {
-				Ok(server_info) => (controller, server_info.default_source_name),
-				Err(e) => {
-					eprintln!("Error getting the Source server info: {}", e);
-					return None;
-				}
-			},
-		};
-
-	// Get the device
-	let device: DeviceInfo = if let Some(name) = get_device_name()
-		&& let Ok(device) = controller.get_device_by_name(&name)
-	{
-		device
-	} else {
-		// Workaround the upstream issues in pulsectl-rs where getting the default source device
-		// doesn't work...
-		match controller.get_device_by_name(&default_name.unwrap_or("".to_string())) {
-			Ok(device) => device,
-			Err(e) => {
-				eprintln!("Error getting the default device: {}", e);
-				return None;
-			}
+	let device = match get_device_name() {
+		Some(name) => ctrl.get_device_by_name(&name),
+		None => ctrl.get_default_device(),
+	};
+	let device = match device {
+		Ok(d) => d,
+		Err(e) => {
+			eprintln!("Error getting device: {}", e);
+			return None;
 		}
 	};
 
-	// Adjust the volume / mute state
 	const VOLUME_CHANGE_DELTA: f64 = 5_f64;
 	let delta = volume_from_f64(
 		step.unwrap_or_default()
@@ -307,21 +278,21 @@ pub fn change_device_volume(
 		VolumeChangeType::Raise => {
 			let max_volume = volume_from_f64(get_max_volume() as f64);
 			if let Some(volume) = device.volume.clone().inc_clamp(delta, max_volume) {
-				controller.set_device_volume_by_index(device.index, volume);
+				ctrl.set_volume_by_index(device.index, &volume);
 			}
 		}
 		VolumeChangeType::Lower => {
 			if let Some(volume) = device.volume.clone().decrease(delta) {
-				controller.set_device_volume_by_index(device.index, volume);
+				ctrl.set_volume_by_index(device.index, &volume);
 			}
 		}
 		VolumeChangeType::MuteToggle => {
-			controller.set_device_mute_by_index(device.index, !device.mute);
+			ctrl.set_mute_by_index(device.index, !device.mute);
 		}
 	}
 
-	match controller.get_device_by_index(device.index) {
-		Ok(device) => Some(device),
+	match ctrl.get_device_by_index(device.index) {
+		Ok(d) => Some(d),
 		Err(e) => {
 			eprintln!("Pulse Error: {}", e);
 			None

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -2,15 +2,17 @@ use gtk::glib::{system_config_dirs, user_config_dir};
 use lazy_static::lazy_static;
 
 use std::{
+	cell::RefCell,
 	fs::{self, File},
 	io::{prelude::*, BufReader},
 	path::{Path, PathBuf},
+	rc::Rc,
 	sync::Mutex,
 };
 
 use pulse::volume::Volume;
 
-use crate::pulse::{DeviceInfo, VolumeController};
+use crate::pulse::{DeviceInfo, DeviceKind, VolumeController};
 
 use crate::brightness_backend;
 use crate::playerctl::PlayerctlDeviceRaw;
@@ -267,13 +269,17 @@ fn volume_from_f64(volume: f64) -> Volume {
 }
 
 pub fn change_device_volume(
-	ctrl: &mut VolumeController,
+	ctrl: &Rc<RefCell<Option<VolumeController>>>,
+	kind: DeviceKind,
 	change_type: VolumeChangeType,
 	step: Option<String>,
 ) -> Option<DeviceInfo> {
+	let mut guard = ctrl.borrow_mut();
+	let ctrl = guard.as_mut()?;
+
 	let device = match get_device_name() {
-		Some(name) => ctrl.get_device_by_name(&name),
-		None => ctrl.get_default_device(),
+		Some(name) => ctrl.get_device_by_name(kind, &name),
+		None => ctrl.get_default_device(kind),
 	};
 	let device = match device {
 		Ok(d) => d,
@@ -293,20 +299,20 @@ pub fn change_device_volume(
 		VolumeChangeType::Raise => {
 			let max_volume = volume_from_f64(get_max_volume() as f64);
 			if let Some(volume) = device.volume.clone().inc_clamp(delta, max_volume) {
-				ctrl.set_volume_by_index(device.index, &volume);
+				ctrl.set_volume_by_index(kind, device.index, volume);
 			}
 		}
 		VolumeChangeType::Lower => {
 			if let Some(volume) = device.volume.clone().decrease(delta) {
-				ctrl.set_volume_by_index(device.index, &volume);
+				ctrl.set_volume_by_index(kind, device.index, volume);
 			}
 		}
 		VolumeChangeType::MuteToggle => {
-			ctrl.set_mute_by_index(device.index, !device.mute);
+			ctrl.set_mute_by_index(kind, device.index, !device.mute);
 		}
 	}
 
-	match ctrl.get_device_by_index(device.index) {
+	match ctrl.get_device_by_index(kind, device.index) {
 		Ok(d) => Some(d),
 		Err(e) => {
 			eprintln!("Pulse Error: {}", e);


### PR DESCRIPTION
`pulsectl-rs` is archived and unmaintained (last commit Aug 2021). Its `SourceController` has copy-paste bugs where `set_device_mute_by_index` and `set_device_volume_by_index` call the sink variants instead of source, so muting/adjusting input volume silently operates on the wrong device. #216 fixed the default device lookup but the mute/volume bug remains.

This replaces `pulsectl-rs` with ~290 lines against `libpulse-binding` (already a direct dependency) using a single `VolumeController` that correctly dispatches to sink or source APIs based on a `DeviceKind` enum. Also removes the unused `substring` dependency.

Fixes #225

Tested manually: output volume raise/lower/mute, input volume raise/lower/mute, custom device via `--device`.