### PR TITLE
Fix --top-margin positioning with fractional scaling

### DIFF
--- a/src/server/osd_window.rs
+++ b/src/server/osd_window.rs
@@ -69,9 +69,7 @@ impl SwayosdWindow {
 		});
 
 		let update_margins = |window: &gtk::ApplicationWindow, monitor: &gdk::Monitor| {
-			// Monitor scale factor is not always correct
-			// Transform monitor height into coordinate system of window
-			let mon_height = monitor.geometry().height() / window.scale_factor();
+			let mon_height = monitor.geometry().height();
 			// Calculate margin from bottom while preserving top_margin semantics:
 			// top_margin=0.85 means window should be at 85% from top, which equals
 			// 15% from bottom. By anchoring to bottom, we avoid issues with


### PR DESCRIPTION
## Summary

`--top-margin` is effectively ignored on displays with fractional scaling (e.g. 1.25x), causing the OSD to always appear near the center of the screen regardless of the configured value.

## Root cause

In `osd_window.rs`, the monitor height used for margin calculation is computed as:

```rust
let mon_height = monitor.geometry().height() / window.scale_factor();
```

`monitor.geometry().height()` already returns logical pixels on Wayland (via `xdg-output`). `window.scale_factor()` returns a ceiled integer (GTK4 rounds fractional scales up — e.g. 1.25 becomes 2). Dividing logical pixels by this ceiled scale factor produces roughly half the actual screen height, so the bottom margin always lands near the vertical center.

For example, on a 3840x2160 display at 1.25x scale:
- `monitor.geometry().height()` = 1728 (logical pixels, already correct)
- `window.scale_factor()` = 2 (GTK4 ceils 1.25)
- `mon_height` = 1728 / 2 = 864 (wrong — half the actual logical height)
- With `--top-margin 0.05`: margin = 864 * 0.95 = 821px from bottom, which is ~center on a 1728px screen

## Fix

Remove the `/ window.scale_factor()` division since the geometry height is already in logical coordinates.

## Testing

Tested on Hyprland with dual monitors:
- DP-2: 3840x2160 @ 1.25x scale
- eDP-1: 1920x1200 @ 1.0x scale

Before: `--top-margin 0.05` shows OSD at screen center on the fractionally-scaled display.
After: `--top-margin 0.05` correctly positions the OSD near the top edge. Works on both monitors.